### PR TITLE
Enable timing-meter batting in Sandlot Showdown

### DIFF
--- a/css/backyard-showdown.css
+++ b/css/backyard-showdown.css
@@ -1,0 +1,817 @@
+:root {
+	--bg-night: radial-gradient(
+		circle at top,
+		#0e1a44 0%,
+		#081024 55%,
+		#03060e 100%
+	);
+	--panel: rgba(15, 29, 73, 0.75);
+	--panel-border: rgba(255, 255, 255, 0.12);
+	--chip-bg: #f9a826;
+	--chip-text: #1b1b1b;
+	--text-primary: #f1f5f9;
+	--text-muted: #cbd5f5;
+	--accent-orange: #ff914d;
+	--accent-teal: #25d0b4;
+	--accent-gold: #facc15;
+	--accent-raspberry: #f87171;
+	--base-inactive: rgba(255, 255, 255, 0.3);
+	--base-active: #facc15;
+	--log-hit: rgba(37, 208, 180, 0.18);
+	--log-out: rgba(248, 113, 113, 0.18);
+	--log-walk: rgba(250, 204, 21, 0.18);
+	--log-score: rgba(244, 114, 182, 0.18);
+	--card-radius: 20px;
+	--shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.55);
+	--shadow-md: 0 16px 40px rgba(0, 0, 0, 0.4);
+}
+
+* {
+	box-sizing: border-box;
+}
+
+body {
+	margin: 0;
+	min-height: 100vh;
+	background: var(--bg-night);
+	color: var(--text-primary);
+	font-family:
+		"Nunito", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+		sans-serif;
+	display: flex;
+	align-items: stretch;
+	justify-content: center;
+	padding: 24px;
+}
+
+.game-shell {
+	width: min(1280px, 100%);
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	position: relative;
+}
+
+.score-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
+	gap: 20px;
+	background: var(--panel);
+	border: 1px solid var(--panel-border);
+	border-radius: var(--card-radius);
+	padding: 24px 28px;
+	box-shadow: var(--shadow-md);
+}
+
+.title-block h1 {
+	font-family: "Fredoka One", cursive;
+	font-size: clamp(1.8rem, 2.6vw, 2.8rem);
+	margin: 6px 0;
+	letter-spacing: 1px;
+}
+
+.brand-tag {
+	display: inline-block;
+	padding: 6px 12px;
+	border-radius: 999px;
+	background: linear-gradient(
+		135deg,
+		var(--accent-orange),
+		var(--accent-raspberry)
+	);
+	color: #03060e;
+	font-weight: 700;
+	font-size: 0.85rem;
+	letter-spacing: 0.5px;
+}
+
+.subtitle {
+	margin: 0;
+	font-size: 1rem;
+	color: var(--text-muted);
+}
+
+.status-panel {
+	display: flex;
+	gap: 12px;
+}
+
+.status-chip {
+	background: var(--chip-bg);
+	color: var(--chip-text);
+	font-weight: 800;
+	letter-spacing: 0.6px;
+	padding: 10px 18px;
+	border-radius: 999px;
+	min-width: 100px;
+	text-align: center;
+	text-transform: uppercase;
+	box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.2);
+}
+
+.game-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 20px;
+}
+
+.team-panel {
+	display: flex;
+}
+
+.team-card {
+	flex: 1;
+	background: var(--panel);
+	border: 1px solid var(--panel-border);
+	border-radius: var(--card-radius);
+	padding: 22px 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	box-shadow: var(--shadow-lg);
+	position: relative;
+	overflow: hidden;
+}
+
+.team-card::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	background: linear-gradient(
+		160deg,
+		rgba(255, 255, 255, 0.08) 0%,
+		transparent 50%
+	);
+}
+
+.team-meta h2 {
+	margin: 0;
+	font-family: "Fredoka One", cursive;
+	font-size: clamp(1.3rem, 2vw, 1.9rem);
+}
+
+.team-motto {
+	margin: 6px 0 0;
+	font-size: 0.95rem;
+	color: var(--text-muted);
+}
+
+.lineup {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.lineup li {
+	display: grid;
+	grid-template-columns: auto 1fr auto;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 14px;
+	border-radius: 14px;
+	background: rgba(9, 15, 30, 0.65);
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	transition:
+		transform 0.25s ease,
+		border-color 0.25s ease,
+		box-shadow 0.25s ease;
+}
+
+.lineup li.active {
+	border-color: var(--accent-gold);
+	transform: translateX(6px);
+	box-shadow: 0 12px 24px rgba(250, 204, 21, 0.25);
+}
+
+.player-order {
+	font-weight: 800;
+	font-size: 0.9rem;
+	color: var(--accent-gold);
+}
+
+.player-name {
+	font-weight: 700;
+	font-size: 1rem;
+}
+
+.player-detail {
+	font-size: 0.85rem;
+	color: var(--text-muted);
+}
+
+.player-emoji {
+	font-size: 1.4rem;
+}
+
+.center-stage {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 18px;
+}
+
+.field-wrapper {
+	width: 100%;
+	background: var(--panel);
+	border: 1px solid var(--panel-border);
+	border-radius: var(--card-radius);
+	padding: 24px;
+	position: relative;
+	overflow: hidden;
+	box-shadow: var(--shadow-lg);
+}
+
+.field {
+	aspect-ratio: 1 / 1;
+	width: 100%;
+	max-width: 480px;
+	margin: 0 auto;
+	position: relative;
+}
+
+.field-backdrop {
+	position: absolute;
+	inset: 0;
+	border-radius: 30px;
+	background: radial-gradient(
+		circle at 40% 20%,
+		rgba(255, 255, 255, 0.08),
+		transparent 55%
+	);
+}
+
+.diamond {
+	position: absolute;
+	inset: 12%;
+	border-radius: 32px;
+	background: linear-gradient(
+		135deg,
+		rgba(27, 65, 43, 0.95),
+		rgba(15, 46, 34, 0.9)
+	);
+	border: 4px solid rgba(255, 255, 255, 0.08);
+	backdrop-filter: blur(4px);
+}
+
+.outfield {
+	position: absolute;
+	inset: -12% -12% auto -12%;
+	width: 124%;
+	transform: translateY(-5%);
+	opacity: 0.85;
+}
+
+.pitcher-mound {
+	position: absolute;
+	inset: 44% 44%;
+	border-radius: 50%;
+	border: 3px solid rgba(236, 184, 94, 0.7);
+	background: rgba(139, 69, 19, 0.6);
+	box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.4);
+}
+
+.base {
+	position: absolute;
+	width: 58px;
+	height: 58px;
+	border-radius: 12px;
+	border: 3px solid rgba(0, 0, 0, 0.35);
+	background: var(--base-inactive);
+	transform: rotate(45deg);
+	transition:
+		background 0.3s ease,
+		box-shadow 0.3s ease;
+}
+
+.base::after {
+	content: "";
+	position: absolute;
+	inset: 18%;
+	border-radius: 4px;
+	background: rgba(255, 255, 255, 0.35);
+}
+
+.base.active {
+	background: var(--base-active);
+	box-shadow: 0 12px 30px rgba(250, 204, 21, 0.5);
+}
+
+.base-home {
+	bottom: 8%;
+	left: 50%;
+	transform: translateX(-50%) rotate(45deg);
+}
+
+.base-first {
+	bottom: 34%;
+	right: 8%;
+}
+
+.base-second {
+	top: 8%;
+	left: 50%;
+	transform: translateX(-50%) rotate(45deg);
+}
+
+.base-third {
+	bottom: 34%;
+	left: 8%;
+}
+
+.batter-spot {
+	margin-top: 18px;
+	background: rgba(9, 15, 32, 0.85);
+	border-radius: 18px;
+	padding: 16px 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.batter-label {
+	font-size: 0.9rem;
+	letter-spacing: 0.8px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+}
+
+.batter-card {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+}
+
+.batter-avatar {
+	width: 72px;
+	height: 72px;
+	border-radius: 18px;
+	background: linear-gradient(
+		135deg,
+		rgba(37, 208, 180, 0.45),
+		rgba(37, 99, 235, 0.45)
+	);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 2.2rem;
+	box-shadow: 0 12px 26px rgba(37, 208, 180, 0.35);
+}
+
+.batter-name {
+	font-family: "Fredoka One", cursive;
+	font-size: 1.4rem;
+	margin-bottom: 6px;
+}
+
+.batter-detail {
+	font-size: 0.95rem;
+	color: var(--text-muted);
+}
+
+.highlight-banner {
+	margin-top: 18px;
+	padding: 14px 18px;
+	border-radius: 16px;
+	background: linear-gradient(
+		135deg,
+		rgba(248, 113, 113, 0.8),
+		rgba(250, 204, 21, 0.8)
+	);
+	color: #0b0b0b;
+	font-weight: 800;
+	text-align: center;
+	letter-spacing: 0.8px;
+	text-transform: uppercase;
+	opacity: 0;
+	transform: translateY(12px);
+	transition:
+		opacity 0.4s ease,
+		transform 0.4s ease;
+}
+
+.highlight-banner.show {
+	opacity: 1;
+	transform: translateY(0);
+}
+
+.highlight-banner.hit {
+	background: linear-gradient(
+		135deg,
+		rgba(37, 208, 180, 0.9),
+		rgba(58, 221, 178, 0.9)
+	);
+}
+
+.highlight-banner.score {
+	background: linear-gradient(
+		135deg,
+		rgba(244, 114, 182, 0.92),
+		rgba(250, 204, 21, 0.92)
+	);
+}
+
+.highlight-banner.out {
+	background: linear-gradient(
+		135deg,
+		rgba(248, 113, 113, 0.92),
+		rgba(255, 156, 156, 0.92)
+	);
+}
+
+.highlight-banner.walk {
+	background: linear-gradient(
+		135deg,
+		rgba(250, 204, 21, 0.9),
+		rgba(96, 165, 250, 0.9)
+	);
+}
+
+.swing-zone {
+	width: 100%;
+	background: var(--panel);
+	border: 1px solid var(--panel-border);
+	border-radius: var(--card-radius);
+	padding: 18px 22px 24px;
+	box-shadow: var(--shadow-md);
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.swing-zone__header h2 {
+	margin: 0;
+	font-size: 1.2rem;
+	letter-spacing: 0.6px;
+}
+
+.swing-zone__header p {
+	margin: 6px 0 0;
+	font-size: 0.9rem;
+	color: var(--text-muted);
+}
+
+.swing-meter {
+	width: 100%;
+	max-width: 420px;
+	align-self: center;
+}
+
+.meter-track {
+	position: relative;
+	width: 100%;
+	height: 36px;
+	border-radius: 999px;
+	background: linear-gradient(
+		135deg,
+		rgba(15, 23, 42, 0.95),
+		rgba(30, 41, 59, 0.95)
+	);
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	overflow: hidden;
+	box-shadow: inset 0 0 12px rgba(15, 23, 42, 0.9);
+}
+
+.meter-target {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	border-radius: 999px;
+	background: linear-gradient(
+		135deg,
+		rgba(250, 204, 21, 0.55),
+		rgba(253, 224, 71, 0.85)
+	);
+	box-shadow: inset 0 0 18px rgba(250, 204, 21, 0.6);
+	transition:
+		left 0.25s ease,
+		width 0.25s ease,
+		opacity 0.25s ease;
+	opacity: 0.65;
+}
+
+.meter-pointer {
+	position: absolute;
+	top: 50%;
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	background: linear-gradient(
+		135deg,
+		rgba(37, 208, 180, 0.95),
+		rgba(14, 165, 233, 0.95)
+	);
+	border: 2px solid rgba(15, 23, 42, 0.9);
+	box-shadow: 0 0 16px rgba(14, 165, 233, 0.65);
+	transform: translate(-50%, -50%);
+	left: 0%;
+	transition: box-shadow 0.2s ease;
+}
+
+.meter-pointer.live {
+	box-shadow: 0 0 22px rgba(37, 208, 180, 0.85);
+}
+
+.swing-hint {
+	margin: 0;
+	font-size: 0.9rem;
+	color: rgba(226, 232, 240, 0.88);
+	text-align: center;
+}
+
+.hud {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 20px;
+}
+
+.scoreboard-card,
+.log-card,
+.control-card {
+	background: var(--panel);
+	border: 1px solid var(--panel-border);
+	border-radius: var(--card-radius);
+	padding: 22px 24px;
+	box-shadow: var(--shadow-md);
+}
+
+.scoreboard-card h2,
+.log-card h2,
+.control-card h2 {
+	font-family: "Fredoka One", cursive;
+	margin: 0 0 8px;
+	font-size: 1.4rem;
+}
+
+.scoreboard-note,
+.log-note {
+	margin: 0 0 18px;
+	color: var(--text-muted);
+	font-size: 0.95rem;
+}
+
+.score-table {
+	width: 100%;
+	border-collapse: collapse;
+	text-align: center;
+	font-weight: 700;
+}
+
+.score-table thead th {
+	font-size: 0.85rem;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	padding-bottom: 8px;
+}
+
+.score-table tbody td,
+.score-table tbody th {
+	padding: 10px 6px;
+	border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.team-label {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	font-size: 0.95rem;
+	text-align: left;
+}
+
+.team-swatch {
+	width: 14px;
+	height: 14px;
+	border-radius: 50%;
+	display: inline-block;
+	background: rgba(255, 255, 255, 0.4);
+}
+
+.score-total {
+	font-size: 1.2rem;
+}
+
+.log-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	max-height: 260px;
+	overflow-y: auto;
+}
+
+.log-list li {
+	padding: 12px 14px;
+	border-radius: 12px;
+	background: rgba(9, 15, 32, 0.8);
+	border: 1px solid rgba(255, 255, 255, 0.06);
+	font-size: 0.95rem;
+	line-height: 1.4;
+	display: flex;
+	gap: 10px;
+	align-items: center;
+}
+
+.log-list li.hit {
+	background: var(--log-hit);
+}
+.log-list li.out {
+	background: var(--log-out);
+}
+.log-list li.walk {
+	background: var(--log-walk);
+}
+.log-list li.score {
+	background: var(--log-score);
+}
+
+.log-tag {
+	font-weight: 800;
+	text-transform: uppercase;
+	font-size: 0.75rem;
+	letter-spacing: 0.7px;
+	padding: 3px 8px;
+	border-radius: 999px;
+	background: rgba(255, 255, 255, 0.15);
+}
+
+.control-card .control-row {
+	display: flex;
+	gap: 12px;
+	flex-wrap: wrap;
+	align-items: center;
+	margin-bottom: 14px;
+}
+
+.control-btn {
+	background: linear-gradient(
+		135deg,
+		rgba(255, 145, 77, 0.95),
+		rgba(255, 197, 61, 0.95)
+	);
+	border: none;
+	color: #1b1b1b;
+	padding: 12px 18px;
+	border-radius: 14px;
+	font-weight: 800;
+	letter-spacing: 0.6px;
+	cursor: pointer;
+	transition:
+		transform 0.2s ease,
+		box-shadow 0.2s ease;
+	box-shadow: 0 10px 24px rgba(255, 145, 77, 0.3);
+}
+
+.control-btn:hover,
+.control-btn:focus-visible {
+	transform: translateY(-2px);
+	box-shadow: 0 14px 28px rgba(255, 145, 77, 0.45);
+}
+
+.control-btn:disabled {
+	cursor: not-allowed;
+	opacity: 0.55;
+	box-shadow: none;
+	transform: none;
+}
+
+.control-btn.control-btn--accent {
+	background: linear-gradient(
+		135deg,
+		rgba(37, 208, 180, 0.95),
+		rgba(14, 165, 233, 0.95)
+	);
+	color: #021c24;
+	box-shadow: 0 10px 26px rgba(14, 165, 233, 0.35);
+}
+
+.control-btn.control-btn--accent:hover,
+.control-btn.control-btn--accent:focus-visible {
+	box-shadow: 0 14px 30px rgba(37, 208, 180, 0.45);
+}
+
+.control-btn.control-btn--accent[aria-pressed="true"] {
+	transform: translateY(-1px);
+	box-shadow: 0 12px 32px rgba(37, 208, 180, 0.55);
+}
+
+.control-hint {
+	margin: 0;
+	font-size: 0.85rem;
+	color: var(--text-muted);
+}
+
+.game-footer {
+	text-align: center;
+	font-size: 0.9rem;
+	color: rgba(203, 213, 225, 0.7);
+}
+
+.final-banner {
+	position: fixed;
+	inset: 0;
+	background: rgba(2, 6, 23, 0.78);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.3s ease;
+	z-index: 999;
+}
+
+.final-banner.show {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.final-card {
+	background: rgba(16, 29, 66, 0.95);
+	padding: 28px 32px;
+	border-radius: 22px;
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	text-align: center;
+	box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+	max-width: 360px;
+}
+
+.final-card h2 {
+	font-family: "Fredoka One", cursive;
+	margin-top: 0;
+	font-size: 1.8rem;
+}
+
+.final-card p {
+	color: var(--text-muted);
+	margin-bottom: 20px;
+}
+
+@media (max-width: 1100px) {
+	body {
+		padding: 18px;
+	}
+
+	.game-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.team-panel:first-child {
+		order: -1;
+	}
+
+	.hud {
+		grid-template-columns: 1fr;
+	}
+}
+
+@media (max-width: 720px) {
+	body {
+		padding: 14px;
+	}
+
+	.score-header {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.status-panel {
+		width: 100%;
+		justify-content: space-between;
+	}
+
+	.field-wrapper {
+		padding: 18px;
+	}
+
+	.field {
+		max-width: 100%;
+	}
+
+	.control-card .control-row {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.control-btn {
+		width: 100%;
+		text-align: center;
+	}
+}
+
+@media (max-width: 520px) {
+	.lineup li {
+		grid-template-columns: 1fr;
+		text-align: center;
+	}
+
+	.player-detail {
+		display: none;
+	}
+}

--- a/games/baseball/README.md
+++ b/games/baseball/README.md
@@ -1,322 +1,78 @@
-# Sandlot Superstars - Baseball Championship Game
+# Sandlot Showdown – Three-Inning Backyard Demo
 
-A fully-featured 3D baseball game built with Three.js, featuring unique characters, special abilities, dynamic stadiums, and immersive gameplay.
+Sandlot Showdown delivers a fully playable three-inning baseball game starring two all-original neighborhood teams. The presentation nods to classic backyard baseball while steering clear of any protected characters, trademarks, or audio/visual assets from existing franchises.
 
-## Table of Contents
+## Quick Start
 
-- [Overview](#overview)
-- [Features](#features)
-- [Getting Started](#getting-started)
-- [Project Structure](#project-structure)
-- [Game Systems](#game-systems)
-- [Development](#development)
-- [Configuration](#configuration)
-- [Browser Support](#browser-support)
-- [Credits](#credits)
-
-## Overview
-
-Sandlot Superstars is a browser-based baseball game that combines arcade-style gameplay with strategic depth. Players can choose from 18 unique characters across 6 teams, each with special abilities and distinct playing styles. The game features realistic 3D graphics, physics-based ball movement, AI-controlled fielders, and procedurally-generated audio.
-
-## Features
-
-### Core Gameplay
-- ⚾ **Full 3D Baseball Field** - Realistic diamond with outfield walls, bases, and pitcher's mound
-- 🎮 **Intuitive Controls** - Keyboard and button controls for batting, pitching, and fielding
-- 🤖 **AI Fielders** - 9 defensive players with intelligent ball-tracking behavior
-- 🎯 **Physics Engine** - Realistic ball trajectory, gravity, and collision detection
-
-### Character System
-- 👥 **18 Unique Characters** - Each with distinct stats and personalities
-- ⚡ **Special Abilities** - Unique powers like Mega Blast, Lightning Speed, and Rocket Arm
-- 📊 **Balanced Stats** - Batting, power, speed, pitching, and fielding ratings (1-10 scale)
-- 🏆 **6 Teams** - Pre-built team rosters with themed characters
-
-### Stadium Variety
-- 🌞 **Sunny Park** - Classic grass field with perfect conditions
-- 🏖️ **Sandy Shores Beach** - Beach setting with wind and sand hazards
-- 🏙️ **Urban Lot** - City field with close fences and building obstacles
-- 🌙 **Night Stadium** - Evening game with reduced visibility under lights
-- ❄️ **Winter Wonderland** - Snow-covered field with unique ball physics
-- 🏜️ **Dusty Diamond** - Desert field with dust storms and hard ground
-
-### Audio & Visual Effects
-- 🔊 **Procedural Audio** - Web Audio API generates realistic sound effects
-- 🎨 **Dynamic Lighting** - Stadium lights and day/night cycles
-- 💥 **Hit Indicators** - Visual feedback for hits, home runs, and outs
-- 📣 **Commentary System** - Dynamic play-by-play announcements
-
-## Getting Started
-
-### Running Locally
-
-1. **Clone the repository:**
+1. **Serve the site locally**
    ```bash
-   git clone https://github.com/ahump20/lone-star-legends-championship.git
-   cd lone-star-legends-championship
+   npm install
+   npm run dev
+   # or use any static server
    ```
+2. **Navigate to the demo** – open [`http://localhost:3000/games/baseball/`](http://localhost:3000/games/baseball/) (or your chosen port).
+3. **Play ball** – the Orbiters bat automatically; when the Roadrunners come up, ride the timing meter and swing.
 
-2. **Start a local web server:**
+## Game Flow
 
-   Using Python 3:
-   ```bash
-   python -m http.server 8000
-   ```
+- **Length** – three innings, top and bottom halves. Home team (Roadrunners) walks off when leading in the 3rd.
+- **Teams** – Oakdale Orbiters vs. Cactus Gulch Roadrunners. Each squad features 9 custom players with contact, power, speed, discipline, and pitching traits.
+- **Top halves (Orbiters)** – CPU-driven plate appearances. Tap **Next Play / Pitch** (or press Space) to advance each matchup.
+- **Bottom halves (Roadrunners)** – you control every at-bat. Launch a pitch with **Next Play / Pitch**, then time your swing in the gold zone for solid contact.
+- **Scoring** – bases advance automatically with full tracking of runs, hits, RBIs, walks, home runs, and runners left on base.
+- **Finish** – ties remain ties after three innings to honor sandlot rules; no extras.
 
-   Or using Node.js:
-   ```bash
-   npx http-server -p 8000
-   ```
+## Controls
 
-3. **Open in browser:**
-   Navigate to `http://localhost:8000/games/baseball/`
+| Action | Desktop | Mobile/Tablet |
+| --- | --- | --- |
+| Start pitch / advance play | `Space` (when meter idle) | Tap **Next Play / Pitch** |
+| Swing | `Space` (when meter live) or `J` | Tap **Swing!** |
+| Reset game | `R` | Tap **Reset Game** |
 
-### Controls
+> Space handles both duties: when no pitch is live it starts the next offering, and when the pointer glows it unleashes your swing.
 
-**Keyboard:**
-- `SPACE` - Swing bat
-- `P` - Pitch ball
-- `R` - Reset game
-- `A` / `Left Arrow` - Move batter left
-- `D` / `Right Arrow` - Move batter right
+## Timing Meter 101
 
-**Mouse/Touch:**
-- Click buttons at bottom of screen for swing, pitch, reset
+- The gold window represents the hittable zone. Its width adjusts based on batter discipline vs. pitcher command.
+- A live pitch lights the teal pointer. Fire the **Swing!** button (or Space/J) when the pointer overlaps the gold for hard contact.
+- Perfect timing powers doubles, triples, and backyard bombs. Late or early swings turn into weak contact or fouls.
+- Lay off the pitch and you’ll either take a strike or watch ball four force in a run depending on the pitcher’s accuracy.
 
-## Project Structure
+## UI Highlights
+
+- **Scoreboard** – inning-by-inning table with hits column and color-coded swatches for each club.
+- **Lineups** – kid-sized baseball cards on the rails show batting order, emoji badges, and live stat lines. The current batter glows gold.
+- **Field & Meter** – stylized sandlot diamond sits above the interactive timing meter so you can track the situation and the next pitch simultaneously.
+- **Play Log** – rolling feed of the last twelve moments with tags for hits, outs, walks, and scoring plays.
+- **Game Over Modal** – walk-off wins, visiting victories, and ties each surface a tailored message.
+
+## Gameplay Notes
+
+- **CPU swings** still use weighted outcomes built from batter power/contact/speed vs. pitcher skill, so the Orbiters feel alive.
+- **Manual swings** factor the Roadrunners’ attributes—better contact widens the sweet spot, elite power turns green bars into souvenirs.
+- **Base running** implements forced advancement on walks plus proper scoring on singles through home runs.
+- **Accessibility** – aria-live regions announce inning/outs, meter instructions, and big-moment banners for assistive tech.
+
+## File Structure
 
 ```
 games/baseball/
-├── index.html              # Main game file
-└── README.md              # This file
+├── index.html              # Main game surface and UI scaffolding
+├── README.md               # This document
 
-js/                         # JavaScript modules (root level)
-├── character-manager.js   # Character/roster management
-├── stadium-manager.js     # Stadium definitions and physics
-├── audio-manager.js       # Sound effects and commentary
-├── special-abilities.js   # Special ability system
-├── enhanced-3d-engine.js  # Advanced 3D rendering (if separate)
-├── character-renderer.js  # Character visualization
-├── enhanced-game-ui.js    # UI components
-├── season-mode.js         # Season/tournament mode
-└── game-integration.js    # Game flow integration
+css/
+└── backyard-showdown.css   # Backyard-inspired visual theme
 
-data/
-└── backyard-roster.json   # Character and team definitions
+js/
+└── backyard-showdown.js    # Game state machine, timing meter, and logic
 ```
 
-## Game Systems
+## Extending the Demo
 
-### Character Management
+- **Add more teams** – duplicate a roster block in `js/backyard-showdown.js`, then expose a selector in the HTML.
+- **Tune the meter** – adjust pitch duration, target width, or contact weighting in `startUserPitch` and `resolveSwingResult`.
+- **Animations & audio** – integrate CSS transitions or Web Audio cues inside `showHighlight` and the timing-meter callbacks.
+- **Persist results** – hook into localStorage to track win/loss records or notable performances across play sessions.
 
-The `CharacterManager` class handles:
-- Loading character roster from JSON
-- Creating player objects with converted stats
-- Team selection and lineup creation
-- Character stat summaries and ratings
-
-**Stat Conversion:**
-- Batting (1-10) → Batting Average (0.200-0.400)
-- Power (1-10) → Power Factor (0.05-0.50)
-- Speed (1-10) → Speed Multiplier (0.5-1.5)
-- Pitching (1-10) → Pitching Skill (0.5-1.0)
-- Fielding (1-10) → Fielding Skill (0.6-1.0)
-
-### Special Abilities
-
-Each character has a unique special ability with a cooldown system:
-
-**Cooldown Values:**
-- `1-9`: Multiple uses per game (uses = floor(9 / cooldown))
-- `99`: One-time use (ultimate ability)
-
-**Ability Types:**
-- **Batting:** Mega Blast, Eagle Eye, Moon Shot, All-Star
-- **Pitching:** Rocket Arm, Trick Pitch
-- **Running:** Lightning Speed, Speedster
-- **Fielding:** Wall Climber, Laser Throw, Magnetic Glove, Defensive Wall, Bike Speed
-- **Team:** Rally Starter, Spark Plug
-
-### Stadium Physics
-
-Each stadium has unique characteristics that affect gameplay:
-
-```javascript
-characteristics: {
-  fenceDistance: 1.0,   // Home run distance multiplier
-  ballSpeed: 1.0,       // Ball velocity multiplier
-  windFactor: 0,        // Wind effect (-0.2 to 0.2)
-  groundSpeed: 1.0,     // Ground ball speed
-  visibility: 1.0       // Affects hitting difficulty
-}
-```
-
-### Audio System
-
-Procedural audio generation using Web Audio API:
-- Bat crack sounds
-- Glove catch pops
-- Crowd cheers and reactions
-- Umpire calls
-- Home run fanfares
-- Dynamic commentary lines
-
-## Development
-
-### Adding New Characters
-
-Edit `/data/backyard-roster.json`:
-
-```json
-{
-  "id": "unique_id",
-  "name": "Player Name",
-  "nickname": "Nickname",
-  "age": 12,
-  "position": "CF",
-  "favoriteNumber": 7,
-  "stats": {
-    "batting": 8,
-    "power": 7,
-    "speed": 9,
-    "pitching": 5,
-    "fielding": 8
-  },
-  "specialAbility": {
-    "id": "ability_id",
-    "name": "Ability Name",
-    "description": "Ability description",
-    "cooldown": 3
-  },
-  "appearance": {
-    "skinTone": "medium",
-    "hairColor": "black",
-    "shirtColor": "#FF6B35"
-  },
-  "personality": {
-    "trait1": "Energetic",
-    "trait2": "Competitive"
-  },
-  "bio": "Character backstory"
-}
-```
-
-### Adding New Special Abilities
-
-1. Define the ability handler in `js/special-abilities.js`:
-
-```javascript
-this.abilityHandlers = {
-  'your_ability_id': (player) => {
-    this.abilityEffects.yourEffect = true;
-    return `${player.name} activates YOUR ABILITY!`;
-  }
-}
-```
-
-2. Implement the effect in `modifyPitchOutcome()`, `modifyFieldingOutcome()`, or `modifyBaseRunning()` methods.
-
-### Adding New Stadiums
-
-Add to `StadiumManager.initializeStadiums()` in `js/stadium-manager.js`:
-
-```javascript
-'your_stadium': {
-  id: 'your_stadium',
-  name: 'Stadium Name',
-  description: 'Stadium description',
-  characteristics: { /* physics modifiers */ },
-  appearance: { /* visual settings */ },
-  ambience: { /* weather and sounds */ }
-}
-```
-
-## Configuration
-
-### Error Handling
-
-The game includes comprehensive error handling:
-- Network request failures show user-friendly error messages
-- Audio initialization failures gracefully disable audio
-- Invalid data structures are validated and logged
-
-### Input Sanitization
-
-All user-provided text (team names, etc.) is sanitized to prevent XSS:
-
-```javascript
-sanitizeHTML(str) {
-  const div = document.createElement('div');
-  div.textContent = str;
-  return div.innerHTML;
-}
-```
-
-### Accessibility
-
-The game includes ARIA labels for screen readers:
-- `role="toolbar"` for game controls
-- `role="status"` for score updates with `aria-live="polite"`
-- `aria-label` attributes on all interactive elements
-
-## Browser Support
-
-**Minimum Requirements:**
-- Modern browser with ES6+ support (Chrome 51+, Firefox 54+, Safari 10+, Edge 15+)
-- WebGL support (for Three.js 3D rendering)
-- Web Audio API support (for sound effects)
-
-**Recommended:**
-- Chrome/Edge 90+
-- Firefox 88+
-- Safari 14+
-- Desktop or tablet (mobile supported but optimized for larger screens)
-
-## Performance Optimization
-
-- Procedural audio reduces file size and HTTP requests
-- Efficient ball physics with cleanup of out-of-bounds objects
-- Optimized fielder AI with distance-based targeting
-- Shadow mapping with PCF soft shadows for visual quality
-
-## Known Limitations
-
-- Single-player only (multiplayer planned for future release)
-- No save/load game state (planned)
-- Limited to 9 innings (configurable in future versions)
-- Procedural audio may be CPU-intensive on low-end devices
-
-## Future Enhancements
-
-- [ ] Online multiplayer support
-- [ ] Save/load game progress
-- [ ] Custom character creation
-- [ ] Tournament/season mode
-- [ ] Achievement system
-- [ ] Replay system
-- [ ] Pre-rendered audio option for performance
-- [ ] Mobile-optimized controls
-- [ ] Localization/internationalization
-
-## Credits
-
-**Development:** Claude (Anthropic)
-**Graphics:** Three.js 3D Engine
-**Audio:** Web Audio API
-**Character System:** Custom roster management
-**Game Design:** Backyard baseball-inspired gameplay
-
-## License
-
-See repository root for license information.
-
-## Support
-
-For issues or questions:
-- Create an issue on GitHub
-- Check existing documentation
-- Review the code comments in source files
-
----
-
-⚾ **Play ball and have fun!**
+Have fun tinkering—this sandlot is safe to share in presentations, product demos, or trade show booths.

--- a/games/baseball/index.html
+++ b/games/baseball/index.html
@@ -3,962 +3,178 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sandlot Superstars - Baseball Championship</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-    <script src="/js/enhanced-3d-engine.js"></script>
-
-    <!-- Sandlot Superstars Styles -->
-    <link rel="stylesheet" href="/css/game-ui.css">
-
-    <!-- Flow State Integration -->
-    <link rel="stylesheet" href="/flow-styles.css" id="flow-state-styles">
-    <script type="module" src="/flow-state-api.js"></script>
-    <script type="module" src="/flow-widgets.js"></script>
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: #0A0A0A;
-            color: white;
-            overflow: hidden;
-        }
-
-        #gameCanvas {
-            width: 100%;
-            height: 100vh;
-            display: block;
-        }
-
-        .ui-overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            padding: 20px;
-            background: linear-gradient(180deg, rgba(0,0,0,0.8) 0%, transparent 100%);
-            pointer-events: none;
-            z-index: 100;
-        }
-
-        .score-board {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            max-width: 600px;
-            margin: 0 auto;
-        }
-
-        .team-score {
-            background: rgba(255, 107, 53, 0.2);
-            border: 2px solid #FF6B35;
-            border-radius: 10px;
-            padding: 15px 25px;
-            min-width: 150px;
-            text-align: center;
-        }
-
-        .team-name {
-            font-size: 14px;
-            color: #FF6B35;
-            text-transform: uppercase;
-            letter-spacing: 1px;
-        }
-
-        .score {
-            font-size: 36px;
-            font-weight: bold;
-            color: white;
-            margin: 5px 0;
-        }
-
-        .inning-display {
-            text-align: center;
-            background: rgba(10, 10, 10, 0.8);
-            border: 2px solid #FF6B35;
-            border-radius: 10px;
-            padding: 10px 20px;
-        }
-
-        .inning-label {
-            font-size: 12px;
-            color: #FF6B35;
-            text-transform: uppercase;
-        }
-
-        .inning-number {
-            font-size: 24px;
-            font-weight: bold;
-        }
-
-        .controls {
-            position: fixed;
-            bottom: 20px;
-            left: 50%;
-            transform: translateX(-50%);
-            display: flex;
-            gap: 20px;
-            z-index: 100;
-        }
-
-        .control-btn {
-            background: linear-gradient(135deg, #FF6B35, #CC5500);
-            border: none;
-            color: white;
-            padding: 15px 30px;
-            border-radius: 10px;
-            font-size: 16px;
-            font-weight: bold;
-            cursor: pointer;
-            transition: all 0.3s;
-            box-shadow: 0 4px 15px rgba(255, 107, 53, 0.3);
-            text-transform: uppercase;
-        }
-
-        .control-btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(255, 107, 53, 0.5);
-        }
-
-        .control-btn:active {
-            transform: translateY(0);
-        }
-
-        .instructions {
-            position: fixed;
-            bottom: 100px;
-            left: 50%;
-            transform: translateX(-50%);
-            background: rgba(0, 0, 0, 0.8);
-            padding: 15px 25px;
-            border-radius: 10px;
-            border: 1px solid #FF6B35;
-            text-align: center;
-            z-index: 100;
-        }
-
-        .hit-indicator {
-            position: fixed;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            font-size: 48px;
-            font-weight: bold;
-            color: #FFD700;
-            text-shadow: 2px 2px 4px rgba(0,0,0,0.8);
-            pointer-events: none;
-            opacity: 0;
-            transition: opacity 0.5s;
-            z-index: 200;
-        }
-
-        .hit-indicator.show {
-            opacity: 1;
-        }
-
-        @media (max-width: 768px) {
-            .score-board {
-                padding: 0 10px;
-            }
-            
-            .team-score {
-                padding: 10px 15px;
-                min-width: 100px;
-            }
-            
-            .score {
-                font-size: 28px;
-            }
-            
-            .controls {
-                bottom: 10px;
-                gap: 10px;
-            }
-            
-            .control-btn {
-                padding: 12px 20px;
-                font-size: 14px;
-            }
-        }
-    </style>
+    <title>Sandlot Showdown – Backyard-Style Baseball Demo</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/backyard-showdown.css">
+    <meta name="description" content="Play a three-inning sandlot baseball showdown with two original teams inspired by classic backyard vibes.">
 </head>
 <body>
-    <canvas id="gameCanvas"></canvas>
-    
-    <div class="ui-overlay" role="region" aria-label="Game status">
-        <div class="score-board" role="status" aria-live="polite">
-            <div class="team-score">
-                <div class="team-name" id="homeTeamName" aria-label="Home team name">Home Team</div>
-                <div class="score" id="homeScore" aria-label="Home team score">0</div>
+    <div class="game-shell" role="application" aria-label="Sandlot Showdown baseball game">
+        <header class="score-header">
+            <div class="title-block">
+                <span class="brand-tag">Sandlot Showdown</span>
+                <h1>Backyard-Style Baseball Demo</h1>
+                <p class="subtitle">Three innings. Two neighborhood legends. Pure sandlot energy.</p>
             </div>
-            <div class="inning-display">
-                <div class="inning-label">Inning</div>
-                <div class="inning-number" id="inning" aria-label="Current inning">1</div>
+            <div class="status-panel" aria-live="polite">
+                <div class="status-chip" id="halfLabel">Top</div>
+                <div class="status-chip" id="inningLabel">1st Inning</div>
+                <div class="status-chip" id="outsLabel">0 Outs</div>
+                <div class="status-chip" id="countLabel">Count 0-0</div>
             </div>
-            <div class="team-score">
-                <div class="team-name" id="awayTeamName" aria-label="Away team name">Away Team</div>
-                <div class="score" id="awayScore" aria-label="Away team score">0</div>
-            </div>
+        </header>
+
+        <main class="game-grid">
+            <section class="team-panel" data-team="0" aria-labelledby="team0Name">
+                <div class="team-card" id="teamCard0">
+                    <div class="team-meta">
+                        <h2 id="team0Name">Oakdale Orbiters</h2>
+                        <p class="team-motto" id="team0Motto">Skyline kids with launchpad swings.</p>
+                    </div>
+                    <ul class="lineup" id="team0Lineup" aria-label="Orbiters lineup"></ul>
+                </div>
+            </section>
+
+            <section class="center-stage">
+                <div class="field-wrapper">
+                    <div class="field" aria-hidden="true">
+                        <div class="field-backdrop"></div>
+                        <div class="diamond">
+                            <div class="base base-home"></div>
+                            <div class="base base-first" data-base="1"></div>
+                            <div class="base base-second" data-base="2"></div>
+                            <div class="base base-third" data-base="3"></div>
+                            <div class="pitcher-mound"></div>
+                            <svg class="outfield" viewBox="0 0 300 220" preserveAspectRatio="xMidYMid slice">
+                                <path d="M150 10 C 40 40, 40 140, 150 210 C 260 140, 260 40, 150 10 Z" fill="url(#grassGradient)" stroke="#104d52" stroke-width="6"/>
+                                <defs>
+                                    <radialGradient id="grassGradient" cx="50%" cy="50%" r="70%">
+                                        <stop offset="0%" stop-color="#2ecc71"/>
+                                        <stop offset="85%" stop-color="#1f7a4d"/>
+                                        <stop offset="100%" stop-color="#145c34"/>
+                                    </radialGradient>
+                                </defs>
+                            </svg>
+                        </div>
+                    </div>
+                    <div class="batter-spot" aria-live="polite">
+                        <div class="batter-label">Current Batter</div>
+                        <div class="batter-card" id="currentBatterCard">
+                            <div class="batter-avatar" id="currentBatterAvatar" aria-hidden="true">⚾️</div>
+                            <div class="batter-info">
+                                <div class="batter-name" id="currentBatterName">—</div>
+                                <div class="batter-detail" id="currentBatterDetail">Waiting for lineups…</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="highlight-banner" id="highlightBanner" role="status" aria-live="polite">Let’s play ball!</div>
+                </div>
+                <section class="swing-zone" aria-label="Batting skill challenge">
+                    <header class="swing-zone__header">
+                        <h2>Timing Meter</h2>
+                        <p>Home team swings manually — land the pointer in the gold zone.</p>
+                    </header>
+                    <div class="swing-meter" role="presentation">
+                        <div class="meter-track">
+                            <div class="meter-target" id="meterTarget"></div>
+                            <div class="meter-pointer" id="meterPointer"></div>
+                        </div>
+                    </div>
+                    <p class="swing-hint" id="swingHint">Press “Next Play” to start a pitch. Press “Swing” (or Space) while the pointer is in the gold.</p>
+                </section>
+            </section>
+
+            <section class="team-panel" data-team="1" aria-labelledby="team1Name">
+                <div class="team-card" id="teamCard1">
+                    <div class="team-meta">
+                        <h2 id="team1Name">Cactus Gulch Roadrunners</h2>
+                        <p class="team-motto" id="team1Motto">Desert dashers with wheels for days.</p>
+                    </div>
+                    <ul class="lineup" id="team1Lineup" aria-label="Roadrunners lineup"></ul>
+                </div>
+            </section>
+        </main>
+
+        <section class="hud">
+            <article class="scoreboard-card" aria-label="Scoreboard">
+                <header>
+                    <h2>Scoreboard</h2>
+                    <p class="scoreboard-note">Three innings. Highest total takes the crown. Ties stay ties—this is sandlot ball.</p>
+                </header>
+                <table class="score-table">
+                    <thead>
+                        <tr>
+                            <th scope="col" class="col-team">Team</th>
+                            <th scope="col">1</th>
+                            <th scope="col">2</th>
+                            <th scope="col">3</th>
+                            <th scope="col" class="col-total">R</th>
+                            <th scope="col" class="col-total">H</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr data-team="0">
+                            <th scope="row" class="team-label">
+                                <span class="team-swatch"></span>
+                                <span class="team-name" data-binding="teamName">Orbiters</span>
+                            </th>
+                            <td data-inning="1">0</td>
+                            <td data-inning="2">0</td>
+                            <td data-inning="3">0</td>
+                            <td class="score-total" data-field="runs">0</td>
+                            <td class="score-total" data-field="hits">0</td>
+                        </tr>
+                        <tr data-team="1">
+                            <th scope="row" class="team-label">
+                                <span class="team-swatch"></span>
+                                <span class="team-name" data-binding="teamName">Roadrunners</span>
+                            </th>
+                            <td data-inning="1">0</td>
+                            <td data-inning="2">0</td>
+                            <td data-inning="3">0</td>
+                            <td class="score-total" data-field="runs">0</td>
+                            <td class="score-total" data-field="hits">0</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </article>
+
+            <article class="log-card" aria-label="Play by play">
+                <header>
+                    <h2>Play by Play</h2>
+                    <p class="log-note">Latest moments first. Big swings glow bright.</p>
+                </header>
+                <ul class="log-list" id="playLog" aria-live="polite"></ul>
+            </article>
+
+            <article class="control-card" aria-label="Game controls">
+                <header>
+                    <h2>Controls</h2>
+                </header>
+                <div class="control-row">
+                    <button type="button" class="control-btn" data-action="play">Next Play / Pitch</button>
+                    <button type="button" class="control-btn control-btn--accent" data-action="swing" aria-pressed="false" disabled>Swing!</button>
+                    <button type="button" class="control-btn" data-action="reset">Reset Game</button>
+                </div>
+                <p class="control-hint">Space: start a pitch or swing when the meter is live. J: swing. R: reset.</p>
+            </article>
+        </section>
+
+        <footer class="game-footer">
+            <p>Original sandlot rosters. Backyard-inspired presentation. Built for quick demos without infringing on the classics.</p>
+        </footer>
+    </div>
+
+    <div class="final-banner" id="finalBanner" role="alertdialog" aria-modal="true" aria-hidden="true">
+        <div class="final-card">
+            <h2 id="finalTitle">Game Over</h2>
+            <p id="finalSubtitle">Thanks for playing Sandlot Showdown!</p>
+            <button type="button" class="control-btn" data-action="close-final">Close</button>
         </div>
     </div>
 
-    <div class="instructions">
-        Use Arrow Keys or WASD to move • SPACE to swing • Click buttons on mobile
-    </div>
-
-    <div class="controls" role="toolbar" aria-label="Game controls">
-        <button class="control-btn" onclick="game.swing()" aria-label="Swing bat">⚾ SWING</button>
-        <button class="control-btn" onclick="game.pitch()" aria-label="Pitch ball">🎯 PITCH</button>
-        <button class="control-btn" onclick="game.reset()" aria-label="Reset game">🔄 RESET</button>
-    </div>
-
-    <div class="hit-indicator" id="hitIndicator">HOME RUN!</div>
-
-    <script>
-        class BaseballGame {
-            constructor() {
-                this.scene = new THREE.Scene();
-                this.camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-                this.renderer = new THREE.WebGLRenderer({ canvas: document.getElementById('gameCanvas'), antialias: true });
-
-                this.homeScore = 0;
-                this.awayScore = 0;
-                this.inning = 1;
-                this.balls = [];
-                this.isSwinging = false;
-                this.batRotation = 0;
-
-                // Team names (can be set externally)
-                this.homeTeamName = 'Home Team';
-                this.awayTeamName = 'Away Team';
-
-                this.init();
-                this.animate();
-            }
-
-            /**
-             * Set team names dynamically
-             */
-            setTeamNames(homeName, awayName) {
-                this.homeTeamName = this.sanitizeHTML(homeName || 'Home Team');
-                this.awayTeamName = this.sanitizeHTML(awayName || 'Away Team');
-                this.updateTeamNamesUI();
-            }
-
-            /**
-             * Sanitize HTML to prevent XSS
-             */
-            sanitizeHTML(str) {
-                const div = document.createElement('div');
-                div.textContent = str;
-                return div.innerHTML;
-            }
-
-            /**
-             * Update team names in UI
-             */
-            updateTeamNamesUI() {
-                const homeEl = document.getElementById('homeTeamName');
-                const awayEl = document.getElementById('awayTeamName');
-                if (homeEl) homeEl.textContent = this.homeTeamName;
-                if (awayEl) awayEl.textContent = this.awayTeamName;
-            }
-
-            init() {
-                // Setup renderer
-                this.renderer.setSize(window.innerWidth, window.innerHeight);
-                this.renderer.shadowMap.enabled = true;
-                this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-                this.scene.fog = new THREE.Fog(0x0A0A0A, 100, 500);
-
-                // Camera position
-                this.camera.position.set(0, 15, 30);
-                this.camera.lookAt(0, 0, 0);
-
-                // Lighting
-                const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
-                this.scene.add(ambientLight);
-
-                const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
-                directionalLight.position.set(50, 100, 50);
-                directionalLight.castShadow = true;
-                directionalLight.shadow.camera.left = -50;
-                directionalLight.shadow.camera.right = 50;
-                directionalLight.shadow.camera.top = 50;
-                directionalLight.shadow.camera.bottom = -50;
-                this.scene.add(directionalLight);
-
-                // Create stadium lights
-                this.createStadiumLights();
-
-                // Create field
-                this.createField();
-
-                // Create bases
-                this.createBases();
-
-                // Create pitcher's mound
-                this.createPitchersMound();
-
-                // Create batter
-                this.createBatter();
-
-                // Create bat
-                this.createBat();
-
-                // Setup controls
-                this.setupControls();
-
-                // Handle window resize
-                window.addEventListener('resize', () => this.onWindowResize());
-            }
-
-            createField() {
-                // Main field (grass)
-                const fieldGeometry = new THREE.PlaneGeometry(200, 200);
-                const fieldMaterial = new THREE.MeshLambertMaterial({ color: 0x2D5016 });
-                const field = new THREE.Mesh(fieldGeometry, fieldMaterial);
-                field.rotation.x = -Math.PI / 2;
-                field.receiveShadow = true;
-                this.scene.add(field);
-
-                // Infield (dirt)
-                const infieldGeometry = new THREE.CircleGeometry(30, 32, 0, Math.PI / 2);
-                const infieldMaterial = new THREE.MeshLambertMaterial({ color: 0x8B7355 });
-                const infield = new THREE.Mesh(infieldGeometry, infieldMaterial);
-                infield.rotation.x = -Math.PI / 2;
-                infield.rotation.z = -Math.PI / 4;
-                infield.position.y = 0.01;
-                this.scene.add(infield);
-
-                // Foul lines
-                const lineGeometry = new THREE.PlaneGeometry(1, 100);
-                const lineMaterial = new THREE.MeshBasicMaterial({ color: 0xFFFFFF });
-                
-                const leftLine = new THREE.Mesh(lineGeometry, lineMaterial);
-                leftLine.rotation.x = -Math.PI / 2;
-                leftLine.rotation.z = Math.PI / 4;
-                leftLine.position.set(-35, 0.02, -35);
-                this.scene.add(leftLine);
-
-                const rightLine = new THREE.Mesh(lineGeometry, lineMaterial);
-                rightLine.rotation.x = -Math.PI / 2;
-                rightLine.rotation.z = -Math.PI / 4;
-                rightLine.position.set(35, 0.02, -35);
-                this.scene.add(rightLine);
-
-                // Outfield wall
-                const wallGeometry = new THREE.BoxGeometry(140, 10, 2);
-                const wallMaterial = new THREE.MeshLambertMaterial({ color: 0x1a4d2e });
-                const wall = new THREE.Mesh(wallGeometry, wallMaterial);
-                wall.position.set(0, 5, -70);
-                wall.castShadow = true;
-                this.scene.add(wall);
-            }
-
-            createBases() {
-                const baseGeometry = new THREE.BoxGeometry(2, 0.2, 2);
-                const baseMaterial = new THREE.MeshLambertMaterial({ color: 0xFFFFFF });
-
-                // Home plate
-                const homePlate = new THREE.Mesh(baseGeometry, baseMaterial);
-                homePlate.position.set(0, 0.1, 0);
-                this.scene.add(homePlate);
-
-                // First base
-                const firstBase = new THREE.Mesh(baseGeometry, baseMaterial);
-                firstBase.position.set(20, 0.1, -20);
-                this.scene.add(firstBase);
-
-                // Second base
-                const secondBase = new THREE.Mesh(baseGeometry, baseMaterial);
-                secondBase.position.set(0, 0.1, -40);
-                this.scene.add(secondBase);
-
-                // Third base
-                const thirdBase = new THREE.Mesh(baseGeometry, baseMaterial);
-                thirdBase.position.set(-20, 0.1, -20);
-                this.scene.add(thirdBase);
-            }
-
-            createPitchersMound() {
-                const moundGeometry = new THREE.CylinderGeometry(3, 4, 0.5, 32);
-                const moundMaterial = new THREE.MeshLambertMaterial({ color: 0x8B7355 });
-                const mound = new THREE.Mesh(moundGeometry, moundMaterial);
-                mound.position.set(0, 0.25, -18);
-                this.scene.add(mound);
-
-                // Pitcher
-                const pitcherGeometry = new THREE.CapsuleGeometry(0.5, 2, 8, 16);
-                const pitcherMaterial = new THREE.MeshLambertMaterial({ color: 0xFF6B35 });
-                this.pitcher = new THREE.Mesh(pitcherGeometry, pitcherMaterial);
-                this.pitcher.position.set(0, 2, -18);
-                this.pitcher.castShadow = true;
-                this.scene.add(this.pitcher);
-
-                // Add all defensive players
-                this.createAllPlayers();
-            }
-
-            createAllPlayers() {
-                // Catcher
-                const catcherGeometry = new THREE.CapsuleGeometry(0.5, 2, 8, 16);
-                const catcherMaterial = new THREE.MeshLambertMaterial({ color: 0x0A0E27 });
-                this.catcher = new THREE.Mesh(catcherGeometry, catcherMaterial);
-                this.catcher.position.set(0, 2, 3);
-                this.catcher.castShadow = true;
-                this.scene.add(this.catcher);
-
-                // Infielders
-                const infielderMaterial = new THREE.MeshLambertMaterial({ color: 0x0A0E27 });
-                
-                // First Base
-                this.firstBase = new THREE.Mesh(new THREE.CapsuleGeometry(0.5, 2, 8, 16), infielderMaterial);
-                this.firstBase.position.set(15, 2, -12);
-                this.firstBase.castShadow = true;
-                this.scene.add(this.firstBase);
-
-                // Second Base
-                this.secondBase = new THREE.Mesh(new THREE.CapsuleGeometry(0.5, 2, 8, 16), infielderMaterial);
-                this.secondBase.position.set(8, 2, -25);
-                this.secondBase.castShadow = true;
-                this.scene.add(this.secondBase);
-
-                // Third Base
-                this.thirdBase = new THREE.Mesh(new THREE.CapsuleGeometry(0.5, 2, 8, 16), infielderMaterial);
-                this.thirdBase.position.set(-15, 2, -12);
-                this.thirdBase.castShadow = true;
-                this.scene.add(this.thirdBase);
-
-                // Shortstop
-                this.shortstop = new THREE.Mesh(new THREE.CapsuleGeometry(0.5, 2, 8, 16), infielderMaterial);
-                this.shortstop.position.set(-8, 2, -25);
-                this.shortstop.castShadow = true;
-                this.scene.add(this.shortstop);
-
-                // Outfielders
-                const outfielderMaterial = new THREE.MeshLambertMaterial({ color: 0x0A0E27 });
-
-                // Left Field
-                this.leftField = new THREE.Mesh(new THREE.CapsuleGeometry(0.5, 2, 8, 16), outfielderMaterial);
-                this.leftField.position.set(-40, 2, -70);
-                this.leftField.castShadow = true;
-                this.scene.add(this.leftField);
-
-                // Center Field
-                this.centerField = new THREE.Mesh(new THREE.CapsuleGeometry(0.5, 2, 8, 16), outfielderMaterial);
-                this.centerField.position.set(0, 2, -85);
-                this.centerField.castShadow = true;
-                this.scene.add(this.centerField);
-
-                // Right Field
-                this.rightField = new THREE.Mesh(new THREE.CapsuleGeometry(0.5, 2, 8, 16), outfielderMaterial);
-                this.rightField.position.set(40, 2, -70);
-                this.rightField.castShadow = true;
-                this.scene.add(this.rightField);
-
-                // Store all fielders for AI control
-                this.fielders = [
-                    { mesh: this.catcher, name: 'catcher', basePos: { x: 0, z: 3 } },
-                    { mesh: this.firstBase, name: 'firstBase', basePos: { x: 15, z: -12 } },
-                    { mesh: this.secondBase, name: 'secondBase', basePos: { x: 8, z: -25 } },
-                    { mesh: this.thirdBase, name: 'thirdBase', basePos: { x: -15, z: -12 } },
-                    { mesh: this.shortstop, name: 'shortstop', basePos: { x: -8, z: -25 } },
-                    { mesh: this.leftField, name: 'leftField', basePos: { x: -40, z: -70 } },
-                    { mesh: this.centerField, name: 'centerField', basePos: { x: 0, z: -85 } },
-                    { mesh: this.rightField, name: 'rightField', basePos: { x: 40, z: -70 } }
-                ];
-
-                console.log('⚾ All 10 players created and positioned');
-            }
-
-            createBatter() {
-                const batterGeometry = new THREE.CapsuleGeometry(0.5, 2, 8, 16);
-                const batterMaterial = new THREE.MeshLambertMaterial({ color: 0x1E90FF });
-                this.batter = new THREE.Mesh(batterGeometry, batterMaterial);
-                this.batter.position.set(0, 2, 2);
-                this.batter.castShadow = true;
-                this.scene.add(this.batter);
-            }
-
-            createBat() {
-                const batGeometry = new THREE.CylinderGeometry(0.1, 0.3, 3, 16);
-                const batMaterial = new THREE.MeshLambertMaterial({ color: 0x8B4513 });
-                this.bat = new THREE.Mesh(batGeometry, batMaterial);
-                this.bat.position.set(1, 2.5, 2);
-                this.bat.rotation.z = Math.PI / 4;
-                this.bat.castShadow = true;
-                this.scene.add(this.bat);
-            }
-
-            createStadiumLights() {
-                const lightPositions = [
-                    [-40, 30, -40],
-                    [40, 30, -40],
-                    [-40, 30, 20],
-                    [40, 30, 20]
-                ];
-
-                lightPositions.forEach(pos => {
-                    // Light pole
-                    const poleGeometry = new THREE.CylinderGeometry(0.5, 0.5, 30, 8);
-                    const poleMaterial = new THREE.MeshLambertMaterial({ color: 0x333333 });
-                    const pole = new THREE.Mesh(poleGeometry, poleMaterial);
-                    pole.position.set(pos[0], 15, pos[2]);
-                    this.scene.add(pole);
-
-                    // Light fixture
-                    const light = new THREE.PointLight(0xFFFFFF, 0.5, 100);
-                    light.position.set(pos[0], pos[1], pos[2]);
-                    this.scene.add(light);
-
-                    // Light bulb visual
-                    const bulbGeometry = new THREE.SphereGeometry(1, 16, 16);
-                    const bulbMaterial = new THREE.MeshBasicMaterial({ 
-                        color: 0xFFFF00,
-                        emissive: 0xFFFF00,
-                        emissiveIntensity: 0.5
-                    });
-                    const bulb = new THREE.Mesh(bulbGeometry, bulbMaterial);
-                    bulb.position.set(pos[0], pos[1], pos[2]);
-                    this.scene.add(bulb);
-                });
-            }
-
-            pitch() {
-                // Create baseball
-                const ballGeometry = new THREE.SphereGeometry(0.2, 16, 16);
-                const ballMaterial = new THREE.MeshLambertMaterial({ color: 0xFFFFFF });
-                const ball = new THREE.Mesh(ballGeometry, ballMaterial);
-                ball.position.copy(this.pitcher.position);
-                ball.position.y = 3;
-                ball.castShadow = true;
-                
-                ball.velocity = new THREE.Vector3(0, 0, 0.8);
-                ball.gravity = -0.01;
-                
-                this.balls.push(ball);
-                this.scene.add(ball);
-
-                // Animate pitcher
-                this.pitcher.rotation.x = -0.3;
-                setTimeout(() => {
-                    this.pitcher.rotation.x = 0;
-                }, 200);
-            }
-
-            swing() {
-                if (this.isSwinging) return;
-                
-                this.isSwinging = true;
-                this.batRotation = 0;
-                
-                // Check for hits
-                this.balls.forEach(ball => {
-                    const distance = ball.position.distanceTo(this.bat.position);
-                    if (distance < 2 && ball.position.z > -1 && ball.position.z < 3) {
-                        // Hit!
-                        ball.velocity.z = -1.5;
-                        ball.velocity.y = 0.8;
-                        ball.velocity.x = (Math.random() - 0.5) * 0.8;
-                        
-                        // Trigger AI fielding
-                        this.startAIFielding(ball);
-                        
-                        // Check if it's a home run
-                        if (Math.random() > 0.7) {
-                            this.showHitIndicator('HOME RUN!');
-                            this.homeScore++;
-                            this.updateScore();
-                        } else if (Math.random() > 0.5) {
-                            this.showHitIndicator('DOUBLE!');
-                        } else {
-                            this.showHitIndicator('HIT!');
-                        }
-                    }
-                });
-
-                setTimeout(() => {
-                    this.isSwinging = false;
-                }, 500);
-            }
-
-            startAIFielding(ball) {
-                if (!this.fielders) return;
-                
-                // Find closest fielder to the ball
-                let closestFielder = null;
-                let closestDistance = Infinity;
-                
-                this.fielders.forEach(fielder => {
-                    const distance = fielder.mesh.position.distanceTo(ball.position);
-                    if (distance < closestDistance) {
-                        closestDistance = distance;
-                        closestFielder = fielder;
-                    }
-                });
-                
-                if (closestFielder) {
-                    console.log(`⚾ ${closestFielder.name} is pursuing the ball`);
-                    this.moveFielderToBall(closestFielder, ball);
-                }
-            }
-
-            moveFielderToBall(fielder, ball) {
-                // Simple AI movement toward ball
-                const direction = new THREE.Vector3()
-                    .subVectors(ball.position, fielder.mesh.position)
-                    .normalize();
-                
-                const targetPosition = ball.position.clone()
-                    .add(direction.multiplyScalar(-2)); // Stop 2 units before ball
-                
-                // Animate fielder movement
-                const startPos = fielder.mesh.position.clone();
-                const endPos = targetPosition;
-                let animationProgress = 0;
-                
-                const animateFielder = () => {
-                    animationProgress += 0.02;
-                    if (animationProgress < 1) {
-                        fielder.mesh.position.lerpVectors(startPos, endPos, animationProgress);
-                        requestAnimationFrame(animateFielder);
-                    } else {
-                        console.log(`⚾ ${fielder.name} reached the ball position`);
-                        // Return to base position after 2 seconds
-                        setTimeout(() => {
-                            this.returnFielderToBase(fielder);
-                        }, 2000);
-                    }
-                };
-                
-                animateFielder();
-            }
-
-            returnFielderToBase(fielder) {
-                const startPos = fielder.mesh.position.clone();
-                const endPos = new THREE.Vector3(fielder.basePos.x, 2, fielder.basePos.z);
-                let animationProgress = 0;
-                
-                const animateReturn = () => {
-                    animationProgress += 0.01;
-                    if (animationProgress < 1) {
-                        fielder.mesh.position.lerpVectors(startPos, endPos, animationProgress);
-                        requestAnimationFrame(animateReturn);
-                    }
-                };
-                
-                animateReturn();
-            }
-
-            showHitIndicator(text) {
-                const indicator = document.getElementById('hitIndicator');
-                indicator.textContent = text;
-                indicator.classList.add('show');
-                setTimeout(() => {
-                    indicator.classList.remove('show');
-                }, 2000);
-            }
-
-            updateScore() {
-                document.getElementById('homeScore').textContent = this.homeScore;
-                document.getElementById('awayScore').textContent = this.awayScore;
-                document.getElementById('inning').textContent = this.inning;
-            }
-
-            reset() {
-                // Remove all balls
-                this.balls.forEach(ball => {
-                    this.scene.remove(ball);
-                });
-                this.balls = [];
-                
-                // Reset scores
-                this.homeScore = 0;
-                this.awayScore = 0;
-                this.inning = 1;
-                this.updateScore();
-            }
-
-            setupControls() {
-                document.addEventListener('keydown', (event) => {
-                    switch(event.code) {
-                        case 'Space':
-                            event.preventDefault();
-                            this.swing();
-                            break;
-                        case 'KeyP':
-                            this.pitch();
-                            break;
-                        case 'KeyR':
-                            this.reset();
-                            break;
-                        case 'ArrowLeft':
-                        case 'KeyA':
-                            this.batter.position.x = Math.max(-2, this.batter.position.x - 0.5);
-                            this.bat.position.x = this.batter.position.x + 1;
-                            break;
-                        case 'ArrowRight':
-                        case 'KeyD':
-                            this.batter.position.x = Math.min(2, this.batter.position.x + 0.5);
-                            this.bat.position.x = this.batter.position.x + 1;
-                            break;
-                    }
-                });
-            }
-
-            onWindowResize() {
-                this.camera.aspect = window.innerWidth / window.innerHeight;
-                this.camera.updateProjectionMatrix();
-                this.renderer.setSize(window.innerWidth, window.innerHeight);
-            }
-
-            animate() {
-                requestAnimationFrame(() => this.animate());
-
-                // Update balls
-                this.balls.forEach((ball, index) => {
-                    ball.position.add(ball.velocity);
-                    ball.velocity.y += ball.gravity;
-                    
-                    // Remove balls that go out of bounds
-                    if (ball.position.z > 10 || ball.position.z < -100 || 
-                        Math.abs(ball.position.x) > 100 || ball.position.y < 0) {
-                        this.scene.remove(ball);
-                        this.balls.splice(index, 1);
-                    }
-                });
-
-                // Animate bat swing
-                if (this.isSwinging) {
-                    this.batRotation += 0.3;
-                    this.bat.rotation.y = -this.batRotation;
-                    if (this.batRotation > Math.PI) {
-                        this.bat.rotation.y = 0;
-                    }
-                }
-
-                // Slight camera movement for dynamism
-                this.camera.position.x = Math.sin(Date.now() * 0.0001) * 2;
-                this.camera.position.y = 15 + Math.sin(Date.now() * 0.0002) * 1;
-                this.camera.lookAt(0, 0, -10);
-
-                this.renderer.render(this.scene, this.camera);
-            }
-        }
-
-        // Initialize Enhanced Baseball Game with all players
-        console.log('⚾ Initializing Enhanced 3D Baseball Game with all players...');
-        const game = new BaseballGame();
-
-        // Auto-pitch every 4 seconds for continuous gameplay
-        setInterval(() => {
-            if (game.balls.length < 2) {
-                game.pitch();
-            }
-        }, 4000);
-
-        // Enhanced player status indicator
-        const playerIndicator = document.createElement('div');
-        playerIndicator.innerHTML = `
-          <div style="position: fixed; top: 80px; right: 20px; background: rgba(255,107,53,0.9); color: white; padding: 15px; border-radius: 10px; font-weight: bold; z-index: 100; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
-            ⚾ 3D Players: 13 Active
-            <br>🤖 AI Fielding: Enhanced
-            <br>🎯 Camera: Interactive
-            <br>📊 Physics: Real-time
-          </div>
-        `;
-        document.body.appendChild(playerIndicator);
-
-        // Enhanced controls help
-        const controlsHelp = document.createElement('div');
-        controlsHelp.innerHTML = `
-          <div style="position: fixed; top: 80px; left: 20px; background: rgba(10,14,39,0.9); color: white; padding: 15px; border-radius: 10px; font-size: 12px; z-index: 100; box-shadow: 0 4px 15px rgba(0,0,0,0.3); border: 1px solid #FF6B35;">
-            <div style="color: #FF6B35; font-weight: bold; margin-bottom: 8px;">3D CONTROLS</div>
-            🖱️ Mouse: Rotate Camera<br>
-            🖱️ Wheel: Zoom<br>
-            ⌨️ Arrow Keys: Move Camera<br>
-            ⌨️ Q/E: Camera Height<br>
-            ⌨️ Space: Pitch Ball<br>
-            🎮 All players auto-controlled
-          </div>
-        `;
-        document.body.appendChild(controlsHelp);
-    </script>
-    
-    <!-- Flow Meter Widget -->
-    <div id="flow-meter-container"></div>
-    
-    <script type="module">
-        import { FlowMeterWidget } from './flow-widgets.js';
-        
-        // Initialize flow meter for game
-        document.addEventListener('DOMContentLoaded', () => {
-            const flowMeter = new FlowMeterWidget('flow-meter-container', {
-                autoStart: true,
-                showMSPE: true,
-                enableBreathing: true
-            });
-            
-            window.blazeFlowMeter = flowMeter;
-        });
-        
-        // Game integration - listen for flow challenge changes
-        window.addEventListener('flowChallengeChange', (event) => {
-            const { level } = event.detail;
-            
-            // Adjust game difficulty - modify auto-pitch frequency
-            if (window.autoPitchInterval) {
-                clearInterval(window.autoPitchInterval);
-            }
-            
-            // Higher flow challenge = faster pitches
-            const pitchSpeed = Math.max(2000, 6000 - (level * 400));
-            
-            window.autoPitchInterval = setInterval(() => {
-                if (game.balls.length < 2) {
-                    game.pitch();
-                    
-                    // Report performance back to flow system
-                    if (window.flowAPI) {
-                        const accuracy = Math.random() * 100; // Would be actual hit rate
-                        const reactionTime = 200 + Math.random() * 300; // Would be actual reaction time
-                        
-                        window.flowAPI.trackEvent('game_performance', {
-                            score: game.homeScore + game.awayScore,
-                            accuracy,
-                            reactionTime,
-                            challengeLevel: level
-                        });
-                        
-                        // Update flow metrics based on performance
-                        const metrics = {
-                            focus: Math.min(100, accuracy),
-                            engagement: Math.min(100, (game.homeScore + game.awayScore) * 10),
-                            skill: Math.min(100, (1000 / reactionTime) * 10)
-                        };
-                        
-                        window.flowAPI.updateMetrics(metrics);
-                    }
-                }
-            }, pitchSpeed);
-            
-            console.log(`Game difficulty adjusted to level ${level}, pitch speed: ${pitchSpeed}ms`);
-        });
-    </script>
-
-    <!-- Sandlot Superstars Integration -->
-    <script src="/js/character-manager.js"></script>
-    <script src="/js/character-renderer.js"></script>
-    <script src="/js/special-abilities.js"></script>
-    <script src="/js/stadium-manager.js"></script>
-    <script src="/js/audio-manager.js"></script>
-    <script src="/js/enhanced-game-ui.js"></script>
-    <script src="/js/season-mode.js"></script>
-    <script src="/js/game-integration.js"></script>
-
-    <!-- New Enhancement Systems -->
-    <script src="/js/save-system.js"></script>
-    <script src="/js/particle-effects.js"></script>
-    <script src="/js/advanced-mechanics.js"></script>
-    <script src="/js/enhanced-ai.js"></script>
-    <script src="/js/mobile-optimization.js"></script>
-
-    <!-- Customization Systems -->
-    <script src="/js/character-customization.js"></script>
-    <script src="/js/stadium-customization.js"></script>
-
-    <script>
-        // Initialize enhanced systems after game loads
-        document.addEventListener('DOMContentLoaded', () => {
-            console.log('🎮 Initializing Enhanced Game Systems...');
-
-            // Wait for game to be ready
-            setTimeout(() => {
-                if (window.game) {
-                    // Initialize particle effects
-                    if (window.game.scene) {
-                        window.particleEffects = new ParticleEffectsSystem(window.game.scene);
-                        console.log('✨ Particle Effects: Ready');
-
-                        // Hook particle effects into game events
-                        const originalSwing = window.game.swing.bind(window.game);
-                        window.game.swing = function() {
-                            originalSwing();
-                            // Create hit impact particles on successful swing
-                            if (window.game.bat && Math.random() > 0.5) {
-                                const batPos = window.game.bat.position;
-                                window.particleEffects.createHitImpact(batPos, 1.2);
-                            }
-                        };
-                    }
-
-                    // Initialize advanced mechanics
-                    window.advancedMechanics = new AdvancedMechanicsSystem(window.game);
-                    window.advancedMechanics.initialize();
-                    window.game.advancedMechanics = window.advancedMechanics;
-
-                    // Initialize enhanced AI
-                    window.enhancedAI = new EnhancedAISystem(window.game);
-                    window.game.ai = window.enhancedAI;
-
-                    // Load saved difficulty
-                    const savedSettings = window.saveSystem.getSettings();
-                    if (savedSettings && savedSettings.difficulty) {
-                        window.enhancedAI.setDifficulty(savedSettings.difficulty);
-                    }
-
-                    // Initialize mobile optimization (if on mobile)
-                    window.mobileOptimization = new MobileOptimizationSystem(window.game);
-
-                    console.log('✅ All Enhancement Systems: Ready');
-
-                    // Show welcome notification
-                    setTimeout(() => {
-                        if (window.advancedMechanics) {
-                            window.advancedMechanics.showMechanicNotification(
-                                '⚾ Enhanced Features Loaded! Press ❓ for controls',
-                                'info'
-                            );
-                        }
-                    }, 1000);
-                }
-            }, 500);
-        });
-
-        // Track play time for save system
-        let playTimeStart = Date.now();
-        setInterval(() => {
-            if (window.saveSystem && document.hasFocus()) {
-                const elapsed = Date.now() - playTimeStart;
-                window.saveSystem.updatePlayTime(elapsed);
-                playTimeStart = Date.now();
-            }
-        }, 60000); // Update every minute
-
-        // Save game state when scoring
-        if (window.game) {
-            const originalUpdateScore = window.game.updateScore?.bind(window.game);
-            if (originalUpdateScore) {
-                window.game.updateScore = function() {
-                    originalUpdateScore();
-                    // Save current game state
-                    if (window.saveSystem) {
-                        window.saveSystem.saveCurrentGame({
-                            homeScore: window.game.homeScore,
-                            awayScore: window.game.awayScore,
-                            inning: window.game.inning,
-                            homeTeam: window.game.homeTeamName,
-                            awayTeam: window.game.awayTeamName
-                        });
-                    }
-                };
-            }
-        }
-    </script>
+    <script src="/js/backyard-showdown.js" type="module" defer></script>
 </body>
 </html>

--- a/js/backyard-showdown.js
+++ b/js/backyard-showdown.js
@@ -1,0 +1,1240 @@
+const TEAM_DATA = [
+	{
+		name: "Oakdale Orbiters",
+		shortName: "Orbiters",
+		motto: "Skyline kids with launchpad swings.",
+		colors: { primary: "#ff914d", accent: "#facc15" },
+		lineup: [
+			{
+				name: "Jazzy Harper",
+				nickname: "Skyhook",
+				emoji: "🛼",
+				position: "CF",
+				contact: 0.68,
+				power: 0.52,
+				speed: 0.88,
+				discipline: 0.61,
+				pitching: 0.32,
+			},
+			{
+				name: "Theo Sparks",
+				nickname: "Torch",
+				emoji: "🔥",
+				position: "SS",
+				contact: 0.63,
+				power: 0.58,
+				speed: 0.72,
+				discipline: 0.59,
+				pitching: 0.28,
+			},
+			{
+				name: "Riley Moon",
+				nickname: "Orbit",
+				emoji: "🌙",
+				position: "1B",
+				contact: 0.66,
+				power: 0.64,
+				speed: 0.58,
+				discipline: 0.57,
+				pitching: 0.35,
+			},
+			{
+				name: "Maya Cruz",
+				nickname: "Pulse",
+				emoji: "🎧",
+				position: "3B",
+				contact: 0.61,
+				power: 0.49,
+				speed: 0.74,
+				discipline: 0.6,
+				pitching: 0.31,
+			},
+			{
+				name: "Cam Gardner",
+				nickname: "Rotor",
+				emoji: "🛩️",
+				position: "P",
+				contact: 0.54,
+				power: 0.46,
+				speed: 0.62,
+				discipline: 0.65,
+				pitching: 0.72,
+			},
+			{
+				name: "Nia Brooks",
+				nickname: "Glide",
+				emoji: "🪁",
+				position: "LF",
+				contact: 0.6,
+				power: 0.44,
+				speed: 0.86,
+				discipline: 0.53,
+				pitching: 0.3,
+			},
+			{
+				name: "Miles Avery",
+				nickname: "Blueprint",
+				emoji: "📐",
+				position: "C",
+				contact: 0.58,
+				power: 0.48,
+				speed: 0.53,
+				discipline: 0.69,
+				pitching: 0.33,
+			},
+			{
+				name: "Harper Quinn",
+				nickname: "Boost",
+				emoji: "⚡",
+				position: "2B",
+				contact: 0.57,
+				power: 0.43,
+				speed: 0.8,
+				discipline: 0.55,
+				pitching: 0.3,
+			},
+			{
+				name: "Dez Coleman",
+				nickname: "Launch",
+				emoji: "🚀",
+				position: "RF",
+				contact: 0.52,
+				power: 0.62,
+				speed: 0.7,
+				discipline: 0.47,
+				pitching: 0.28,
+			},
+		],
+		pitcherIndex: 4,
+	},
+	{
+		name: "Cactus Gulch Roadrunners",
+		shortName: "Roadrunners",
+		motto: "Desert dashers with wheels for days.",
+		colors: { primary: "#25d0b4", accent: "#60a5fa" },
+		lineup: [
+			{
+				name: "Sunny Delgado",
+				nickname: "Flash",
+				emoji: "🌞",
+				position: "CF",
+				contact: 0.64,
+				power: 0.5,
+				speed: 0.9,
+				discipline: 0.6,
+				pitching: 0.34,
+			},
+			{
+				name: "Kai Navarro",
+				nickname: "Coyote",
+				emoji: "🪶",
+				position: "SS",
+				contact: 0.62,
+				power: 0.55,
+				speed: 0.82,
+				discipline: 0.58,
+				pitching: 0.31,
+			},
+			{
+				name: "June Morales",
+				nickname: "Thunder",
+				emoji: "🌩️",
+				position: "1B",
+				contact: 0.65,
+				power: 0.67,
+				speed: 0.56,
+				discipline: 0.52,
+				pitching: 0.3,
+			},
+			{
+				name: "Atlas Reed",
+				nickname: "Howitzer",
+				emoji: "💥",
+				position: "3B",
+				contact: 0.58,
+				power: 0.71,
+				speed: 0.6,
+				discipline: 0.49,
+				pitching: 0.35,
+			},
+			{
+				name: "Lena Ortiz",
+				nickname: "Screwball",
+				emoji: "🪀",
+				position: "P",
+				contact: 0.52,
+				power: 0.42,
+				speed: 0.68,
+				discipline: 0.66,
+				pitching: 0.74,
+			},
+			{
+				name: "Piper Sloan",
+				nickname: "Jet",
+				emoji: "🛹",
+				position: "LF",
+				contact: 0.6,
+				power: 0.48,
+				speed: 0.86,
+				discipline: 0.55,
+				pitching: 0.29,
+			},
+			{
+				name: "Eli Booker",
+				nickname: "Signal",
+				emoji: "📡",
+				position: "C",
+				contact: 0.56,
+				power: 0.44,
+				speed: 0.54,
+				discipline: 0.67,
+				pitching: 0.32,
+			},
+			{
+				name: "Nova Ellis",
+				nickname: "Skip",
+				emoji: "🪩",
+				position: "2B",
+				contact: 0.55,
+				power: 0.46,
+				speed: 0.78,
+				discipline: 0.62,
+				pitching: 0.28,
+			},
+			{
+				name: "Trace Kim",
+				nickname: "Dustup",
+				emoji: "🌪️",
+				position: "RF",
+				contact: 0.5,
+				power: 0.6,
+				speed: 0.7,
+				discipline: 0.46,
+				pitching: 0.27,
+			},
+		],
+		pitcherIndex: 4,
+	},
+];
+
+const USER_TEAM_INDEX = 1;
+const PITCH_BASE_DURATION = 1500;
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+class TeamState {
+	constructor(config, index) {
+		this.index = index;
+		this.config = config;
+		this.lineup = config.lineup.map((player, order) => {
+			const copy = { ...player };
+			copy.order = order + 1;
+			copy.teamIndex = index;
+			copy.stats = {
+				atBats: 0,
+				hits: 0,
+				runs: 0,
+				rbis: 0,
+				walks: 0,
+				homeRuns: 0,
+			};
+			return copy;
+		});
+		this.pitcherIndex = config.pitcherIndex ?? 0;
+		this.pitcher = this.lineup[this.pitcherIndex];
+		this.lineupCursor = 0;
+		this.runsPerInning = [0, 0, 0];
+		this.totalRuns = 0;
+		this.totalHits = 0;
+	}
+
+	nextBatter() {
+		const batter = this.lineup[this.lineupCursor];
+		this.lineupCursor = (this.lineupCursor + 1) % this.lineup.length;
+		return batter;
+	}
+
+	reset() {
+		this.lineup.forEach((player) => {
+			player.stats.atBats = 0;
+			player.stats.hits = 0;
+			player.stats.runs = 0;
+			player.stats.rbis = 0;
+			player.stats.walks = 0;
+			player.stats.homeRuns = 0;
+		});
+		this.pitcher = this.lineup[this.pitcherIndex];
+		this.lineupCursor = 0;
+		this.runsPerInning = [0, 0, 0];
+		this.totalRuns = 0;
+		this.totalHits = 0;
+	}
+}
+
+class SandlotShowdown {
+	constructor() {
+		this.teams = TEAM_DATA.map((team, index) => new TeamState(team, index));
+		this.inning = 1;
+		this.half = "top";
+		this.outs = 0;
+		this.bases = [null, null, null];
+		this.currentBatter = null;
+		this.count = { balls: 0, strikes: 0 };
+		this.gameOver = false;
+		this.playLog = [];
+
+		this.pitchInProgress = false;
+		this.pitchData = null;
+		this.pitchAnimationFrame = null;
+		this.pitchPointerProgress = 0;
+
+		this.cacheElements();
+		this.bindEvents();
+		this.initializeGame();
+	}
+
+	cacheElements() {
+		this.teamCards = [
+			document.getElementById("teamCard0"),
+			document.getElementById("teamCard1"),
+		];
+		this.teamLineups = [
+			document.getElementById("team0Lineup"),
+			document.getElementById("team1Lineup"),
+		];
+		this.teamMottos = [
+			document.getElementById("team0Motto"),
+			document.getElementById("team1Motto"),
+		];
+		this.teamNameBindings = [
+			document.querySelector('tr[data-team="0"] .team-name'),
+			document.querySelector('tr[data-team="1"] .team-name'),
+		];
+		this.teamSwatches = [
+			document.querySelector('tr[data-team="0"] .team-swatch'),
+			document.querySelector('tr[data-team="1"] .team-swatch'),
+		];
+		this.scoreRows = [
+			document.querySelector('tr[data-team="0"]'),
+			document.querySelector('tr[data-team="1"]'),
+		];
+		this.halfLabel = document.getElementById("halfLabel");
+		this.inningLabel = document.getElementById("inningLabel");
+		this.outsLabel = document.getElementById("outsLabel");
+		this.countLabel = document.getElementById("countLabel");
+		this.highlightBanner = document.getElementById("highlightBanner");
+		this.batterName = document.getElementById("currentBatterName");
+		this.batterDetail = document.getElementById("currentBatterDetail");
+		this.batterAvatar = document.getElementById("currentBatterAvatar");
+		this.playLogList = document.getElementById("playLog");
+		this.finalBanner = document.getElementById("finalBanner");
+		this.finalTitle = document.getElementById("finalTitle");
+		this.finalSubtitle = document.getElementById("finalSubtitle");
+		this.meterTarget = document.getElementById("meterTarget");
+		this.meterPointer = document.getElementById("meterPointer");
+		this.swingHint = document.getElementById("swingHint");
+		this.playButton = document.querySelector('[data-action="play"]');
+		this.swingButton = document.querySelector('[data-action="swing"]');
+	}
+
+	bindEvents() {
+		this.playButton.addEventListener("click", () => this.playNext());
+		document
+			.querySelector('[data-action="reset"]')
+			.addEventListener("click", () => this.resetGame());
+		document
+			.querySelector('[data-action="close-final"]')
+			.addEventListener("click", () => this.hideFinalBanner());
+		this.swingButton.addEventListener("click", () => this.handleSwing());
+
+		window.addEventListener("keydown", (event) => {
+			if (event.code === "Space") {
+				event.preventDefault();
+				if (this.pitchInProgress && this.isUserHalf()) {
+					this.handleSwing();
+				} else {
+					this.playNext();
+				}
+			} else if (event.code === "KeyJ") {
+				event.preventDefault();
+				this.handleSwing();
+			} else if (event.code === "KeyR") {
+				this.resetGame();
+			}
+		});
+	}
+
+	initializeGame() {
+		this.teams.forEach((teamState, index) => {
+			this.renderTeamCard(teamState, index);
+		});
+		this.resetGame();
+	}
+
+	renderTeamCard(teamState, index) {
+		const card = this.teamCards[index];
+		card.style.setProperty("--team-color", teamState.config.colors.primary);
+		card.style.setProperty("--team-accent", teamState.config.colors.accent);
+		const heading = card.querySelector("h2");
+		heading.textContent = teamState.config.name;
+		this.teamMottos[index].textContent = teamState.config.motto;
+		this.teamNameBindings[index].textContent = teamState.config.shortName;
+		this.teamSwatches[index].style.background = teamState.config.colors.primary;
+	}
+
+	resetGame() {
+		this.clearPitchAnimation();
+		this.pitchInProgress = false;
+		this.pitchData = null;
+		this.pitchPointerProgress = 0;
+		this.teams.forEach((team) => {
+			team.reset();
+		});
+		this.inning = 1;
+		this.half = "top";
+		this.outs = 0;
+		this.bases = [null, null, null];
+		this.currentBatter = null;
+		this.count = { balls: 0, strikes: 0 };
+		this.gameOver = false;
+		this.playLog = [];
+		this.finalBanner.classList.remove("show");
+		this.finalBanner.setAttribute("aria-hidden", "true");
+		this.playButton.disabled = false;
+		this.updateSwingButton(false);
+		this.ensureCurrentBatter();
+		this.updateAllUI();
+		this.pushLog({
+			type: "info",
+			text: "Play ball! Orbiters bat first in the top of the 1st.",
+		});
+	}
+
+	updateSwingButton(active) {
+		if (active) {
+			this.swingButton.disabled = false;
+			this.swingButton.setAttribute("aria-pressed", "true");
+		} else {
+			this.swingButton.disabled = true;
+			this.swingButton.setAttribute("aria-pressed", "false");
+		}
+	}
+
+	clearPitchAnimation() {
+		if (this.pitchAnimationFrame) {
+			cancelAnimationFrame(this.pitchAnimationFrame);
+			this.pitchAnimationFrame = null;
+		}
+	}
+
+	isUserHalf() {
+		const battingTeam = this.getBattingTeam();
+		return (
+			!this.gameOver &&
+			this.half === "bottom" &&
+			battingTeam.index === USER_TEAM_INDEX
+		);
+	}
+
+	playNext() {
+		if (this.gameOver || this.pitchInProgress) {
+			return;
+		}
+		this.ensureCurrentBatter();
+		if (this.isUserHalf()) {
+			this.startUserPitch();
+		} else {
+			this.resolveCpuPlateAppearance();
+		}
+	}
+
+	ensureCurrentBatter() {
+		if (this.gameOver) {
+			return;
+		}
+		if (!this.currentBatter) {
+			const battingTeam = this.getBattingTeam();
+			this.currentBatter = battingTeam.nextBatter();
+			this.count = { balls: 0, strikes: 0 };
+		}
+		this.updateCurrentBatterUI();
+		this.updateCountUI();
+	}
+
+	startUserPitch() {
+		const batter = this.currentBatter;
+		if (!batter) {
+			return;
+		}
+		const pitcher = this.getFieldingTeam().pitcher;
+		const controlGap = pitcher.pitching - batter.discipline;
+		const contactBonus = batter.contact - 0.5;
+		const windowWidth = clamp(
+			0.18 - controlGap * 0.08 + contactBonus * 0.04,
+			0.09,
+			0.28,
+		);
+		const center = 0.2 + Math.random() * 0.6;
+		const width = windowWidth;
+		const left = clamp(center - width / 2, 0.02, 0.98 - width);
+		const strikeChance = clamp(
+			0.55 + pitcher.pitching * 0.25 - batter.discipline * 0.18,
+			0.25,
+			0.85,
+		);
+		const duration = clamp(
+			PITCH_BASE_DURATION - (pitcher.pitching - batter.speed) * 300,
+			1050,
+			1900,
+		);
+
+		this.pitchData = {
+			center,
+			radius: width / 2,
+			isStrike: Math.random() < strikeChance,
+			duration,
+			startTime: null,
+		};
+		this.pitchPointerProgress = 0;
+		this.pitchInProgress = true;
+		this.playButton.disabled = true;
+		this.updateSwingButton(true);
+		this.meterPointer.classList.add("live");
+		this.meterPointer.style.left = "0%";
+		this.meterTarget.style.left = `${left * 100}%`;
+		this.meterTarget.style.width = `${width * 100}%`;
+		this.meterTarget.style.opacity = "0.85";
+		this.swingHint.textContent =
+			"Swing while the pointer glows in the gold zone!";
+
+		const step = (timestamp) => {
+			if (!this.pitchInProgress || !this.pitchData) {
+				return;
+			}
+			if (!this.pitchData.startTime) {
+				this.pitchData.startTime = timestamp;
+			}
+			const elapsed = timestamp - this.pitchData.startTime;
+			const progress = clamp(elapsed / this.pitchData.duration, 0, 1);
+			this.pitchPointerProgress = progress;
+			this.meterPointer.style.left = `${progress * 100}%`;
+			if (progress >= 1) {
+				this.handlePitchExpiration();
+				return;
+			}
+			this.pitchAnimationFrame = requestAnimationFrame(step);
+		};
+
+		this.pitchAnimationFrame = requestAnimationFrame(step);
+	}
+
+	handleSwing() {
+		if (!this.pitchInProgress || !this.isUserHalf() || !this.pitchData) {
+			return;
+		}
+		const batter = this.currentBatter;
+		if (!batter) {
+			return;
+		}
+		const pitcher = this.getFieldingTeam().pitcher;
+		const { center, radius } = this.pitchData;
+		const diff = Math.abs(this.pitchPointerProgress - center);
+		const rawQuality = 1 - diff / radius;
+		const adjustedQuality = clamp(
+			rawQuality - (pitcher.pitching - 0.5) * 0.18,
+			-1,
+			1,
+		);
+		this.finishPitch();
+
+		if (adjustedQuality <= 0) {
+			this.recordStrike(
+				batter,
+				`${batter.nickname} comes up empty on the swing.`,
+			);
+			this.updateAllUI();
+			return;
+		}
+
+		const result = this.resolveSwingResult(
+			clamp(adjustedQuality, 0, 1),
+			batter,
+			pitcher,
+		);
+		if (result.type === "foul") {
+			this.handleFoul(batter, result.message);
+			this.updateAllUI();
+			return;
+		}
+		this.applyOutcome(result.type, batter, result.message);
+	}
+
+	resolveSwingResult(quality, batter, _pitcher) {
+		const contact = batter.contact ?? 0.5;
+		const power = batter.power ?? 0.5;
+		const speed = batter.speed ?? 0.5;
+		if (quality > 0.92) {
+			const hrChance = clamp(0.35 + (power - 0.5) * 0.6, 0.1, 0.85);
+			if (Math.random() < hrChance) {
+				return {
+					type: "home_run",
+					message: "Crushed! Moonshot over the neighborhood fence!",
+				};
+			}
+			const tripleChance = clamp(0.2 + (speed - 0.5) * 0.35, 0.05, 0.45);
+			if (Math.random() < tripleChance) {
+				return {
+					type: "triple",
+					message: "Legs churning—triple to the alley!",
+				};
+			}
+			return { type: "double", message: "Smoke to the gap for a double!" };
+		}
+		if (quality > 0.78) {
+			const extraChance = clamp(0.25 + (power - 0.5) * 0.35, 0.05, 0.6);
+			if (Math.random() < extraChance) {
+				return { type: "double", message: "Drives it deep for extra bases!" };
+			}
+			return { type: "single", message: "Lines a single up the middle." };
+		}
+		if (quality > 0.6) {
+			const singleChance = clamp(0.55 + (contact - 0.5) * 0.3, 0.3, 0.85);
+			if (Math.random() < singleChance) {
+				return {
+					type: "single",
+					message: "Drops in front of the fielder for a knock.",
+				};
+			}
+			const outType = Math.random() < 0.5 ? "groundout" : "flyout";
+			return {
+				type: outType,
+				message: "Puts it in play but the defense is ready.",
+			};
+		}
+		if (quality > 0.45) {
+			if (Math.random() < 0.5) {
+				return { type: "foul", message: "Just foul down the line." };
+			}
+			const outType = Math.random() < 0.6 ? "groundout" : "flyout";
+			return { type: outType, message: "Rolls over it for an out." };
+		}
+		return { type: "foul", message: "Nicks it foul to stay alive." };
+	}
+
+	handleFoul(batter, message = "Spoils it foul.") {
+		if (this.count.strikes < 2) {
+			this.count.strikes += 1;
+			this.pushLog({ type: "out", text: `${batter.name}: ${message}` });
+			this.showHighlight(message, "out");
+		} else {
+			this.pushLog({ type: "info", text: `${batter.name}: ${message}` });
+		}
+		this.updateCountUI();
+	}
+
+	recordBall(batter, description) {
+		this.count.balls += 1;
+		if (this.count.balls >= 4) {
+			this.handleWalk(batter);
+			return;
+		}
+		this.pushLog({ type: "walk", text: `${batter.name}: ${description}` });
+		this.showHighlight(description, "walk");
+		this.updateCountUI();
+	}
+
+	recordStrike(batter, description, options = {}) {
+		this.count.strikes += 1;
+		if (this.count.strikes >= 3) {
+			const finalMessage = options.called
+				? "Caught looking at strike three."
+				: description;
+			this.handleOut(batter, finalMessage);
+			return;
+		}
+		const type = options.called ? "info" : "out";
+		this.pushLog({ type, text: `${batter.name}: ${description}` });
+		this.showHighlight(description, "out");
+		this.updateCountUI();
+	}
+	handlePitchExpiration() {
+		if (!this.pitchData) {
+			return;
+		}
+		const batter = this.currentBatter;
+		const wasStrike = this.pitchData.isStrike;
+		this.finishPitch();
+		if (!batter) {
+			return;
+		}
+		if (wasStrike) {
+			this.recordStrike(batter, "Watches strike paint the corner.", {
+				called: true,
+			});
+		} else {
+			this.recordBall(batter, "Lets the pitch sail wide.");
+		}
+		this.updateAllUI();
+	}
+
+	finishPitch() {
+		this.clearPitchAnimation();
+		this.pitchInProgress = false;
+		this.pitchData = null;
+		this.playButton.disabled = this.gameOver;
+		this.updateSwingButton(false);
+		this.meterPointer.classList.remove("live");
+		this.meterPointer.style.left = "0%";
+	}
+
+	updateAllUI() {
+		this.updateStatusChips();
+		this.updateBasesUI();
+		this.updateScoreboard();
+		this.updateLineups();
+		this.updateCurrentBatterUI();
+		this.updateCountUI();
+		if (!this.pitchInProgress) {
+			this.updateMeterIdleState();
+		}
+		this.renderLog();
+	}
+
+	updateMeterIdleState() {
+		if (this.pitchInProgress) {
+			return;
+		}
+		this.meterPointer.classList.remove("live");
+		this.meterPointer.style.left = "0%";
+		if (this.gameOver) {
+			this.meterTarget.style.width = "0%";
+			this.meterTarget.style.opacity = "0.2";
+			this.swingHint.textContent = "Final. Hit reset to run it back.";
+			return;
+		}
+		if (this.isUserHalf()) {
+			this.meterTarget.style.width = "18%";
+			this.meterTarget.style.left = "41%";
+			this.meterTarget.style.opacity = "0.35";
+			this.swingHint.textContent =
+				"Press “Next Play” to start a pitch. Swing while the pointer is in the gold.";
+		} else {
+			this.meterTarget.style.width = "0%";
+			this.meterTarget.style.opacity = "0.15";
+			this.swingHint.textContent =
+				"Orbiters bat automatically—tap “Next Play” to advance plays.";
+		}
+	}
+
+	updateStatusChips() {
+		const halfText = this.half === "top" ? "Top" : "Bottom";
+		const inningSuffix = this.getInningSuffix(this.inning);
+		this.halfLabel.textContent = halfText;
+		this.inningLabel.textContent = `${this.inning}${inningSuffix} Inning`;
+		this.outsLabel.textContent = `${this.outs} ${this.outs === 1 ? "Out" : "Outs"}`;
+	}
+
+	getInningSuffix(inning) {
+		if (inning === 1) return "st";
+		if (inning === 2) return "nd";
+		if (inning === 3) return "rd";
+		return "th";
+	}
+
+	updateScoreboard() {
+		this.teams.forEach((team, index) => {
+			const row = this.scoreRows[index];
+			for (let inning = 1; inning <= 3; inning++) {
+				const cell = row.querySelector(`td[data-inning="${inning}"]`);
+				cell.textContent = team.runsPerInning[inning - 1] ?? 0;
+			}
+			row.querySelector('[data-field="runs"]').textContent = team.totalRuns;
+			row.querySelector('[data-field="hits"]').textContent = team.totalHits;
+		});
+	}
+
+	updateBasesUI() {
+		document.querySelectorAll(".base[data-base]").forEach((base) => {
+			base.classList.remove("active");
+		});
+		this.bases.forEach((runner, index) => {
+			if (runner) {
+				const baseElement = document.querySelector(
+					`.base[data-base="${index + 1}"]`,
+				);
+				if (baseElement) {
+					baseElement.classList.add("active");
+				}
+			}
+		});
+	}
+
+	updateLineups() {
+		this.teams.forEach((team, teamIndex) => {
+			const lineupList = this.teamLineups[teamIndex];
+			lineupList.innerHTML = "";
+			team.lineup.forEach((player) => {
+				const item = document.createElement("li");
+				if (
+					this.currentBatter &&
+					this.currentBatter.name === player.name &&
+					this.currentBatter.teamIndex === teamIndex
+				) {
+					item.classList.add("active");
+				}
+				item.innerHTML = `
+                    <span class="player-order">${player.order}</span>
+                    <span class="player-name">${player.emoji} ${player.name}</span>
+                    <span class="player-detail">${player.position} · ${player.stats.hits}-${player.stats.atBats} · ${player.stats.runs} R</span>
+                `;
+				lineupList.appendChild(item);
+			});
+		});
+	}
+
+	updateCurrentBatterUI() {
+		if (!this.currentBatter) {
+			this.batterName.textContent = "On deck";
+			this.batterDetail.textContent = "Next hitter strides up soon.";
+			this.batterAvatar.textContent = "⚾️";
+			return;
+		}
+		const batter = this.currentBatter;
+		const avg =
+			batter.stats.atBats > 0
+				? batter.stats.hits / batter.stats.atBats
+				: batter.contact;
+		const avgDisplay = avg.toFixed(3).replace("0.", ".");
+		this.batterName.textContent = `${batter.emoji} ${batter.name}`;
+		this.batterDetail.textContent = `${batter.nickname} · ${batter.position} · AVG ${avgDisplay}`;
+		this.batterAvatar.textContent = batter.emoji;
+	}
+
+	updateCountUI() {
+		this.countLabel.textContent = `Count ${this.count.balls}-${this.count.strikes}`;
+	}
+
+	renderLog() {
+		this.playLogList.innerHTML = "";
+		this.playLog.slice(0, 12).forEach((entry) => {
+			const item = document.createElement("li");
+			if (entry.type) {
+				item.classList.add(entry.type);
+			}
+			const tag = document.createElement("span");
+			tag.className = "log-tag";
+			tag.textContent = (entry.type ?? "info").toUpperCase();
+			item.appendChild(tag);
+			const text = document.createElement("span");
+			text.textContent = entry.text;
+			item.appendChild(text);
+			this.playLogList.appendChild(item);
+		});
+	}
+
+	pushLog(entry) {
+		this.playLog.unshift(entry);
+		if (this.playLog.length > 40) {
+			this.playLog.length = 40;
+		}
+		this.renderLog();
+	}
+
+	getBattingTeam() {
+		return this.half === "top" ? this.teams[0] : this.teams[1];
+	}
+
+	getFieldingTeam() {
+		return this.half === "top" ? this.teams[1] : this.teams[0];
+	}
+
+	resolveCpuPlateAppearance() {
+		if (!this.currentBatter) {
+			this.currentBatter = this.getBattingTeam().nextBatter();
+			this.count = { balls: 0, strikes: 0 };
+		}
+		const batter = this.currentBatter;
+		const pitcher = this.getFieldingTeam().pitcher;
+		const outcome = this.determineCpuOutcome(batter, pitcher);
+		this.applyOutcome(outcome, batter);
+	}
+
+	determineCpuOutcome(batter, pitcher) {
+		const battingContact = batter.contact ?? 0.5;
+		const battingPower = batter.power ?? 0.5;
+		const battingSpeed = batter.speed ?? 0.5;
+		const battingDiscipline = batter.discipline ?? 0.5;
+		const pitchingSkill = pitcher.pitching ?? 0.5;
+
+		const outcomes = [
+			{
+				type: "walk",
+				weight: 0.06 + (battingDiscipline - pitchingSkill) * 0.1,
+			},
+			{
+				type: "strikeout",
+				weight: 0.16 + (pitchingSkill - battingContact) * 0.18,
+			},
+			{ type: "single", weight: 0.28 + (battingContact - 0.5) * 0.3 },
+			{ type: "double", weight: 0.12 + (battingPower - 0.5) * 0.18 },
+			{ type: "triple", weight: 0.03 + (battingSpeed - 0.5) * 0.06 },
+			{ type: "home_run", weight: 0.06 + (battingPower - 0.5) * 0.16 },
+			{ type: "groundout", weight: 0.11 - (battingSpeed - 0.5) * 0.12 },
+			{ type: "flyout", weight: 0.08 - (battingPower - 0.5) * 0.08 },
+			{ type: "lineout", weight: 0.04 },
+		];
+
+		const sanitized = outcomes.map((outcome) => ({
+			...outcome,
+			weight: Math.max(0.02, outcome.weight),
+		}));
+		const totalWeight = sanitized.reduce(
+			(sum, outcome) => sum + outcome.weight,
+			0,
+		);
+		let random = Math.random() * totalWeight;
+		for (const outcome of sanitized) {
+			random -= outcome.weight;
+			if (random <= 0) {
+				return outcome.type;
+			}
+		}
+		return "groundout";
+	}
+
+	applyOutcome(type, batter, customMessage) {
+		switch (type) {
+			case "walk":
+				this.handleWalk(batter);
+				break;
+			case "single":
+				this.handleHit(
+					batter,
+					1,
+					customMessage ?? "Rips a single into the gap.",
+				);
+				break;
+			case "double":
+				this.handleHit(
+					batter,
+					2,
+					customMessage ?? "Splits the alley for a stand-up double!",
+				);
+				break;
+			case "triple":
+				this.handleHit(
+					batter,
+					3,
+					customMessage ?? "Rattles off the fence—triple time!",
+				);
+				break;
+			case "home_run":
+				this.handleHit(batter, 4, customMessage ?? "Launches a backyard bomb!");
+				break;
+			case "strikeout":
+				this.handleOut(batter, customMessage ?? "K'd on the heater.");
+				break;
+			case "groundout":
+				this.handleOut(
+					batter,
+					customMessage ?? "Chopped on the ground and scooped.",
+				);
+				break;
+			case "flyout":
+				this.handleOut(
+					batter,
+					customMessage ?? "High fly pulled in on the run.",
+				);
+				break;
+			default:
+				this.handleOut(batter, customMessage ?? "Laser snagged in mid-air.");
+				break;
+		}
+	}
+
+	handleWalk(batter) {
+		batter.stats.walks += 1;
+		this.pushLog({
+			type: "walk",
+			text: `${batter.name} draws ball four and trots to first.`,
+		});
+		const scored = this.advanceWalk(batter);
+		if (scored.length) {
+			this.processRuns(scored, batter, "Ball four forces a run!");
+		} else {
+			this.showHighlight("Ball four! Take your base.", "walk");
+		}
+		this.count = { balls: 0, strikes: 0 };
+		if (this.gameOver) {
+			return;
+		}
+		this.queueNextBatter();
+		this.updateAllUI();
+	}
+
+	handleHit(batter, basesTaken, message) {
+		batter.stats.atBats += 1;
+		batter.stats.hits += 1;
+		if (basesTaken === 4) {
+			batter.stats.homeRuns += 1;
+		}
+		const team = this.getBattingTeam();
+		team.totalHits += 1;
+		const scoredPlayers = this.advanceRunners(basesTaken, batter);
+		const highlightType = basesTaken >= 3 ? "score" : "hit";
+		const runsText = this.describeRuns(scoredPlayers.length, batter);
+		const defaultMessage = message ?? this.defaultHitMessage(basesTaken);
+		const logText = `${batter.name}: ${defaultMessage} ${runsText}`.trim();
+		this.pushLog({ type: highlightType, text: logText });
+		if (scoredPlayers.length) {
+			this.processRuns(scoredPlayers, batter, defaultMessage);
+		} else {
+			this.showHighlight(defaultMessage, highlightType);
+		}
+		if (this.gameOver) {
+			return;
+		}
+		this.queueNextBatter();
+		this.updateAllUI();
+	}
+
+	defaultHitMessage(basesTaken) {
+		if (basesTaken === 1) return "Rips a single into the gap.";
+		if (basesTaken === 2) return "Splits the alley for a stand-up double!";
+		if (basesTaken === 3) return "Rattles off the fence—triple time!";
+		return "Launches a backyard bomb!";
+	}
+
+	describeRuns(runCount, batter) {
+		if (runCount === 0) return "";
+		if (runCount === 1) return `${batter.nickname} plates one.`;
+		if (runCount === 2) return "Two runners hustle home!";
+		if (runCount === 3) return "Bases clear!";
+		return "Everybody scores!";
+	}
+
+	handleOut(batter, description) {
+		batter.stats.atBats += 1;
+		this.outs += 1;
+		this.pushLog({ type: "out", text: `${batter.name}: ${description}` });
+		this.showHighlight(description, "out");
+		if (this.outs >= 3) {
+			this.endHalfInning();
+		} else {
+			this.queueNextBatter();
+			this.updateAllUI();
+		}
+	}
+
+	advanceWalk(batter) {
+		const before = [...this.bases];
+		const newBases = [...this.bases];
+		const scored = [];
+		for (let base = 2; base >= 0; base--) {
+			const runner = before[base];
+			if (!runner) continue;
+			let forced = true;
+			for (let check = 0; check < base; check++) {
+				if (!before[check]) {
+					forced = false;
+					break;
+				}
+			}
+			if (forced) {
+				const destination = base + 1;
+				newBases[base] = null;
+				if (destination >= 3) {
+					scored.push(runner);
+				} else {
+					newBases[destination] = runner;
+				}
+			}
+		}
+		newBases[0] = batter;
+		this.bases = newBases;
+		return scored;
+	}
+
+	advanceRunners(steps, batter) {
+		const prior = [...this.bases];
+		const newBases = [null, null, null];
+		const scored = [];
+		for (let base = 2; base >= 0; base--) {
+			const runner = prior[base];
+			if (!runner) continue;
+			const destination = base + steps;
+			if (destination >= 3) {
+				scored.push(runner);
+			} else {
+				newBases[destination] = runner;
+			}
+		}
+		if (steps >= 4) {
+			scored.push(batter);
+		} else {
+			const batterDestination = steps - 1;
+			if (batterDestination >= 3) {
+				scored.push(batter);
+			} else {
+				newBases[batterDestination] = batter;
+			}
+		}
+		this.bases = newBases;
+		return scored;
+	}
+
+	processRuns(scoredPlayers, batter, highlightMessage) {
+		const battingTeam = this.getBattingTeam();
+		scoredPlayers.forEach((player) => {
+			battingTeam.totalRuns += 1;
+			battingTeam.runsPerInning[this.inning - 1] += 1;
+			player.stats.runs += 1;
+		});
+		batter.stats.rbis += scoredPlayers.length;
+		this.pushLog({
+			type: "score",
+			text: `${scoredPlayers.length} run${scoredPlayers.length === 1 ? "" : "s"} cross. ${highlightMessage}`,
+		});
+		this.showHighlight(`${scoredPlayers.length} score!`, "score");
+		this.checkWalkOff();
+	}
+
+	checkWalkOff() {
+		if (this.inning === 3 && this.half === "bottom") {
+			const home = this.teams[1];
+			const away = this.teams[0];
+			if (home.totalRuns > away.totalRuns) {
+				this.endGame(
+					`${home.config.name} walk it off!`,
+					`${home.totalRuns}-${away.totalRuns} final.`,
+				);
+			}
+		}
+	}
+
+	queueNextBatter() {
+		if (this.gameOver || this.outs >= 3) {
+			return;
+		}
+		const battingTeam = this.getBattingTeam();
+		this.currentBatter = battingTeam.nextBatter();
+		this.count = { balls: 0, strikes: 0 };
+		this.updateCurrentBatterUI();
+		this.updateCountUI();
+		if (this.isUserHalf()) {
+			this.updateMeterIdleState();
+		}
+	}
+
+	endHalfInning() {
+		const battingTeam = this.getBattingTeam();
+		const fieldingTeam = this.getFieldingTeam();
+		this.pushLog({
+			type: "info",
+			text: `${battingTeam.config.shortName} strand ${this.runnersLeft()} and ${fieldingTeam.config.shortName} grab their bats.`,
+		});
+		this.bases = [null, null, null];
+		this.outs = 0;
+		this.currentBatter = null;
+		this.count = { balls: 0, strikes: 0 };
+		this.clearPitchAnimation();
+		this.pitchInProgress = false;
+		this.updateSwingButton(false);
+		if (this.half === "top") {
+			this.half = "bottom";
+			if (
+				this.inning === 3 &&
+				this.teams[1].totalRuns > this.teams[0].totalRuns
+			) {
+				this.endGame(
+					`${this.teams[1].config.name} win it without swinging in the 3rd!`,
+					`${this.teams[1].totalRuns}-${this.teams[0].totalRuns} final.`,
+				);
+				return;
+			}
+		} else {
+			if (this.inning === 3) {
+				this.finishRegulation();
+				return;
+			}
+			this.inning += 1;
+			this.half = "top";
+		}
+		this.ensureCurrentBatter();
+		this.updateAllUI();
+	}
+
+	runnersLeft() {
+		const count = this.bases.filter(Boolean).length;
+		if (count === 0) return "no one";
+		if (count === 1) return "a runner";
+		return `${count} runners`;
+	}
+
+	finishRegulation() {
+		const home = this.teams[1];
+		const away = this.teams[0];
+		if (home.totalRuns > away.totalRuns) {
+			this.endGame(
+				`${home.config.name} defend their turf!`,
+				`${home.totalRuns}-${away.totalRuns} final.`,
+			);
+		} else if (away.totalRuns > home.totalRuns) {
+			this.endGame(
+				`${away.config.name} steal the road win!`,
+				`${away.totalRuns}-${home.totalRuns} final.`,
+			);
+		} else {
+			this.endGame(
+				"Three innings and we stay tied!",
+				`${away.totalRuns}-${home.totalRuns} backyard draw.`,
+			);
+		}
+	}
+
+	showHighlight(message, type) {
+		this.highlightBanner.textContent = message;
+		this.highlightBanner.classList.remove(
+			"show",
+			"hit",
+			"score",
+			"out",
+			"walk",
+		);
+		if (type) {
+			this.highlightBanner.classList.add(type);
+		}
+		requestAnimationFrame(() => {
+			this.highlightBanner.classList.add("show");
+		});
+		clearTimeout(this.highlightTimeout);
+		this.highlightTimeout = setTimeout(() => {
+			this.highlightBanner.classList.remove("show");
+		}, 2000);
+	}
+
+	endGame(title, subtitle) {
+		if (this.gameOver) return;
+		this.gameOver = true;
+		this.finishPitch();
+		this.finalTitle.textContent = title;
+		this.finalSubtitle.textContent = subtitle;
+		this.finalBanner.setAttribute("aria-hidden", "false");
+		this.finalBanner.classList.add("show");
+		this.playButton.disabled = true;
+		this.updateSwingButton(false);
+		this.pushLog({ type: "info", text: `${title} ${subtitle}` });
+		this.updateMeterIdleState();
+		this.updateAllUI();
+	}
+
+	hideFinalBanner() {
+		this.finalBanner.classList.remove("show");
+		this.finalBanner.setAttribute("aria-hidden", "true");
+	}
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+	const game = new SandlotShowdown();
+	window.sandlotShowdown = game;
+});


### PR DESCRIPTION
## Summary
- add an interactive pitch timing meter so the Roadrunners swing manually with new probability tuning and UI hooks
- refresh the baseball game layout to showcase the meter, swing controls, updated status chips, and responsive tweaks
- rewrite the README with timing instructions and control updates for the hybrid CPU/player experience

## Testing
- `npx --yes @biomejs/biome@2.2.2 check games/baseball/index.html css/backyard-showdown.css js/backyard-showdown.js games/baseball/README.md`


------
https://chatgpt.com/codex/tasks/task_e_69061a1b0ccc8330913ffbb0fe21f8e8