### PR TITLE
Enhance 3D stadium environment for game demo

### DIFF
--- a/game-enhanced.html
+++ b/game-enhanced.html
@@ -1097,12 +1097,21 @@
             scoreboardTexture.needsUpdate = true;
         }
 
+        // Track previous base occupation states to avoid unnecessary updates
+        let previousBaseStates = [];
         function update3DBases(bases) {
             if (!baseMeshes || !baseMeshes.length) return;
+            // Initialize previousBaseStates if needed
+            if (previousBaseStates.length !== baseMeshes.length) {
+                previousBaseStates = new Array(baseMeshes.length).fill(null);
+            }
             baseMeshes.forEach((mesh, index) => {
                 const occupied = !!bases[index];
-                mesh.material.emissiveIntensity = occupied ? 0.85 : 0;
-                mesh.material.color.setHex(occupied ? 0xfff0d2 : 0xffffff);
+                if (previousBaseStates[index] !== occupied) {
+                    mesh.material.emissiveIntensity = occupied ? 0.85 : 0;
+                    mesh.material.color.setHex(occupied ? 0xfff0d2 : 0xffffff);
+                    previousBaseStates[index] = occupied;
+                }
             });
         }
 


### PR DESCRIPTION
## Summary
- rebuild the Three.js field to include MLB-style mowing stripes, warning track, infield details, bullpens, dugouts, seating, light towers, and skyline elements
- add a dynamic canvas-driven outfield scoreboard that mirrors live game state updates from the simulation
- introduce base LED glow feedback plus upgraded lighting and camera motion for a production-ready presentation

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_69076bae31d48330a3eb32595fc775be